### PR TITLE
Serving static files when using the built-in webserver.

### DIFF
--- a/webroot/index.php
+++ b/webroot/index.php
@@ -24,7 +24,7 @@ if (php_sapi_name() === 'cli-server') {
 
 	$url = urldecode($_SERVER['REQUEST_URI']);
 	$file = __DIR__ . $url;
-	if (strpos($url, '..') === false && strpos($url, '.') !== false && file_exists($file) && is_file($file)) {
+	if (strpos($url, '..') === false && strpos($url, '.') !== false && is_file($file)) {
 		return false;
 	}
 }


### PR DESCRIPTION
When using built-in webserver static files are not served, instead exceptions are thrown:

```
2013-09-18 14:43:29 Error: [Cake\Error\MissingControllerException] Controller class Css could not be found.
Exception Attributes: array (
  'class' => 'Css',
  'plugin' => NULL,
  'prefix' => NULL,
)
Request URL: /css/cake.generic.css
Stack Trace:
#0 /Users/renan/Sites/cakephp/3.0-app/webroot/index.php(41): Cake\Routing\Dispatcher->dispatch(Object(Cake\Network\Request), Object(Cake\Network\Response))
#1 {main}
2013-09-18 14:43:29 Error: [Cake\Error\MissingControllerException] Controller class Img could not be found.
Exception Attributes: array (
  'class' => 'Img',
  'plugin' => NULL,
  'prefix' => NULL,
)
Request URL: /img/cake.power.gif
Stack Trace:
#0 /Users/renan/Sites/cakephp/3.0-app/webroot/index.php(41): Cake\Routing\Dispatcher->dispatch(Object(Cake\Network\Request), Object(Cake\Network\Response))
#1 {main}
```

The current `AssetDispatcher` only tries to serve themed and plugins' assets.

From PHP's documentation:

> If a PHP file is given on the command line when the web server is started it is treated as a "router" script. The script is run at the start of each HTTP request. If this script returns FALSE, then the requested resource is returned as-is. Otherwise the script's output is returned to the browser.

In order to serve the static files from webroot directory it is necessary to `return false` on the router script and let the webserver serve it.
