### PR TITLE
Trimming bootstrap.php

### DIFF
--- a/App/Config/bootstrap.php
+++ b/App/Config/bootstrap.php
@@ -25,20 +25,16 @@ if (file_exists(ROOT . '/vendor/autoload.php')) {
 	require ROOT . '/vendor/autoload.php';
 }
 
-// If you can't use composer, you can use CakePHP's classloader
-// to autoload your application and the framework. You will
-// also need to add autoloaders for each Plugin you use.
-// This code expects that cakephp will be
-// setup in vendor/cakephp/cakephp.
-/*
-require $root . '/vendor/cakephp/cakephp/src/Core/ClassLoader.php';
-
-$loader = new \Cake\Core\ClassLoader;
-$loader->register();
-
-$loader->addNamespace('App', $root . '/App');
-$loader->addNamespace('Cake', $root . '/vendor/cakephp/cakephp/src');
-*/
+// If composer is not used, use CakePHP's classloader to autoload the framework
+// and the application. You will also need setup autoloading for plugins by
+// passing `autoload' => true for `Plugin::loadAll()` or `Plugin::load()`
+if (!class_exists('Cake\Core\Configure')) {
+	require CAKE . 'Core/ClassLoader.php';
+	$loader = new \Cake\Core\ClassLoader;
+	$loader->register();
+	$loader->addNamespace('Cake', CAKE);
+	$loader->addNamespace(\Cake\Core\Configure::read('App.namespace'), APP);
+}
 
 /**
  * Bootstrap CakePHP.
@@ -81,19 +77,6 @@ try {
 	// Configure::load('app.local.php', 'default');
 } catch (\Exception $e) {
 	die('Unable to load Config/app.php. Create it by copying Config/app.default.php to Config/app.php.');
-}
-
-/**
- * Configure an autoloader for the App namespace.
- *
- * Use App\Controller\AppController as a test to see if composer
- * support is being used.
- */
-if (!class_exists('App\Controller\AppController')) {
-	$loader = new \Cake\Core\ClassLoader;
-	$loader->register();
-
-	$loader->addNamespace(Configure::read('App.namespace'), APP);
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ If Composer is installed globally, run
 1. Clone this repository at desired location.
 2. Clone [CakePHP](https://github.com/cakephp/cakephp) into `vendor/cakephp/cakephp`.
 3. Checkout the `3.0` branch in the new CakePHP clone.
-4. In `App/Config/bootstrap.php` uncomment the section using `Cake\Core\ClassLoader`.
-5. Copy `App/Config/app.default.php` to `App/Config/app.php`
+4. Copy `App/Config/app.default.php` to `App/Config/app.php`
 
 You should now be able to visit the path to where you installed the app and see
 the setup traffic lights.


### PR DESCRIPTION
Removing extra check for setting up App namespace and combining it with framework setup.
This has the benefit of making things `Just Works (tm)` for old timers like me who like to use git submodule.
