### PR TITLE
Fixes `use` statement to the new location of ConnectionManager

### DIFF
--- a/App/Config/bootstrap.php
+++ b/App/Config/bootstrap.php
@@ -55,7 +55,7 @@ use Cake\Console\ConsoleErrorHandler;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Database\ConnectionManager;
+use Cake\Datasource\ConnectionManager;
 use Cake\Error\ErrorHandler;
 use Cake\Log\Log;
 use Cake\Network\Email\Email;


### PR DESCRIPTION
Incorrect path to ConnectionManager
