### PR TITLE
Fix fatal error in home.ctp

### DIFF
--- a/App/Template/Pages/home.ctp
+++ b/App/Template/Pages/home.ctp
@@ -15,7 +15,7 @@
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Database\ConnectionManager;
+use Cake\Datasource\ConnectionManager;
 use Cake\Error;
 use Cake\Utility\Debugger;
 use Cake\Validation\Validation;


### PR DESCRIPTION
Fixes `Error: Class 'Cake\Database\ConnectionManager' not found`
