### PR TITLE
We're not using Configure here, why define it?

### DIFF
--- a/webroot/index.php
+++ b/webroot/index.php
@@ -30,7 +30,6 @@ if (php_sapi_name() === 'cli-server') {
 }
 require dirname(__DIR__) . '/App/Config/bootstrap.php';
 
-use Cake\Core\Configure;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Dispatcher;


### PR DESCRIPTION
The Cake\Core\Configure use statement is unused. So removing it makes sense.
