### PR TITLE
Add cli_bootstrap.php.

### DIFF
--- a/App/Config/bootstrap.php
+++ b/App/Config/bootstrap.php
@@ -96,10 +96,16 @@ mb_internal_encoding(Configure::read('App.encoding'));
 /**
  * Register application error and exception handlers.
  */
-if (php_sapi_name() === 'cli') {
+$isCli = php_sapi_name() === 'cli';
+if ($isCli) {
 	(new ConsoleErrorHandler(Configure::consume('Error')))->register();
 } else {
 	(new ErrorHandler(Configure::consume('Error')))->register();
+}
+
+// Include the CLI bootstrap overrides.
+if ($isCli) {
+	require __DIR__ . '/cli_bootstrap.php';
 }
 
 /**

--- a/App/Config/cli_bootstrap.php
+++ b/App/Config/cli_bootstrap.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+use Cake\Core\Configure;
+
+/**
+ * Additional bootstrapping and configuration for CLI environments should
+ * be put here.
+ */
+
+// Set logs to different files so they don't have permission conflicts.
+Configure::write('Log.debug.file', 'cli-debug');
+Configure::write('Log.error.file', 'cli-error');


### PR DESCRIPTION
Add a CLI specific bootstrap override file. This file is intended to be used for CLI specific config and bootstrapping. For example, by using separate log files for web & cli we can avoid annoying file permission
issues. This addresses cakephp/cakephp#2634 and is part of cakephp/cakephp#3325
