### PR TITLE
Only mention composer as the officially supported install method.

### DIFF
--- a/App/Config/bootstrap.php
+++ b/App/Config/bootstrap.php
@@ -21,22 +21,7 @@ namespace App\Config;
 require __DIR__ . '/paths.php';
 
 // Use composer to load the autoloader.
-if (file_exists(ROOT . '/vendor/autoload.php')) {
-	require ROOT . '/vendor/autoload.php';
-}
-
-// If composer is not used, use CakePHP's classloader to autoload the framework
-// and the application. You will also need setup autoloading for plugins by
-// passing `autoload' => true for `Plugin::loadAll()` or `Plugin::load()`
-//
-// If you are using a custom namespace, you'll need to set it here as well.
-if (!class_exists('Cake\Core\Configure')) {
-	require CAKE . 'Core/ClassLoader.php';
-	$loader = new \Cake\Core\ClassLoader;
-	$loader->register();
-	$loader->addNamespace('Cake', CAKE);
-	$loader->addNamespace('App', APP);
-}
+require ROOT . '/vendor/autoload.php';
 
 /**
  * Bootstrap CakePHP.

--- a/README.md
+++ b/README.md
@@ -6,27 +6,11 @@ This is an unstable repository and should be treated as an alpha.
 
 ## Installation
 
-### Install with composer
-
 1. Download [Composer](http://getcomposer.org/doc/00-intro.md) or update `composer self-update`.
 2. Run `php composer.phar create-project -s dev cakephp/app [app_name]`.
 
 If Composer is installed globally, run
 `composer create-project -s dev cakephp/app [app_name]`
-
-### Manual installation
-
-1. Clone this repository at desired location.
-2. Clone [CakePHP](https://github.com/cakephp/cakephp) into `vendor/cakephp/cakephp`.
-   ```
-   git clone git://github.com/cakephp/cakephp.git vendor/cakephp/cakephp
-   ```
-3. Checkout the `3.0` branch in the new CakePHP clone.
-   ```
-   cd vendor/cakephp/cakephp
-   git checkout -t -b 3.0 origin/3.0
-   ```
-4. Copy `App/Config/app.default.php` to `App/Config/app.php`
 
 You should now be able to visit the path to where you installed the app and see
 the setup traffic lights.


### PR DESCRIPTION
It will make things easier for us and less documentation to worry about.
