### PR TITLE
Add mcrypt and intl extension traffic lights, rename Cake to CakePHP

### DIFF
--- a/App/Template/Pages/home.ctp
+++ b/App/Template/Pages/home.ctp
@@ -118,7 +118,7 @@ endif;
 			echo '<span class="notice success">CakePHP is able to connect to the database.</span>';
 		else:
 			echo '<span class="notice">';
-				echo 'Cake is NOT able to connect to the database.';
+				echo 'CakePHP is NOT able to connect to the database.';
 				echo '<br /><br />';
 				echo $errorMsg;
 			echo '</span>';


### PR DESCRIPTION
Added traffic lights for the `mcrypt` and `intl` extensions.  It crossed my mind that the PHP version and extension traffic lights may not be necessary anymore, now that Composer is the accepted installation method of CakePHP. But, this may still be helpful/newbie-friendly whenever installing in a good environment, but then moving the application to another environment which may not meet the requirements.
