### PR TITLE
Correct issue with assets and query params under PHP CLI Server

### DIFF
--- a/webroot/index.php
+++ b/webroot/index.php
@@ -18,9 +18,9 @@
 if (php_sapi_name() === 'cli-server') {
 	$_SERVER['PHP_SELF'] = '/' . basename(__FILE__);
 
-	$url = urldecode($_SERVER['REQUEST_URI']);
-	$file = __DIR__ . $url;
-	if (strpos($url, '..') === false && strpos($url, '.') !== false && is_file($file)) {
+	$url = parse_url(urldecode($_SERVER['REQUEST_URI']));
+	$file = __DIR__ . $url['path'];
+	if (strpos($url['path'], '..') === false && strpos($url['path'], '.') !== false && is_file($file)) {
 		return false;
 	}
 }


### PR DESCRIPTION
If you try to access an asset file with a query param (For example asset.timestamp is enabled) when running under the PHP CLI server then CakePHP will try to serve that url as a CakePHP route rather than an asset file.
