### PR TITLE
Use `$routes->fallbacks()` instead of repeat code

### DIFF
--- a/src/Config/routes.php
+++ b/src/Config/routes.php
@@ -40,6 +40,10 @@ Router::scope('/', function($routes) {
  * Connect a route for the index action of any controller.
  * And a more general catch all route for any action.
  *
+ * The `fallbacks` method is a shortcut for
+ *    `$this->connect('/:controller', ['action' => 'index'], ['routeClass' => 'InflectedRoute']);`
+ *    `$this->connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);`
+ *
  * You can remove these routes once you've connected the
  * routes you want in your application.
  */


### PR DESCRIPTION
On `Cake\Routing\RouterBuilder` we have a `fallbacks()` method that does exactly what we are doing on routes.php.

I think it's better to use the method because this way users known its existence and will use it instead of copy-pasting two lines of code.
