### PR TITLE
Removed unneeded path mapping for composer's autoloader.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
 	"autoload": {
 		"psr-4": {
 			"App\\": "src",
-			"App\\Test\\": "tests",
-			"": "./plugins"
+			"App\\Test\\": "tests"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
This extra mapping would cause problems for newbies.
