### PR TITLE
Enable identifier quoting in sample db configs.

### DIFF
--- a/src/Config/app.default.php
+++ b/src/Config/app.default.php
@@ -207,7 +207,7 @@ $config = [
 			'prefix' => false,
 			'encoding' => 'utf8',
 			'timezone' => 'UTC',
-			'quoteIdentifiers' => false,
+			'quoteIdentifiers' => true,
 			'cacheMetadata' => true,
 			/* During development, if using MySQL < 5.6, uncommenting the following line
 			* could boost the speed at which schema metadata is fetched from the database.
@@ -231,7 +231,7 @@ $config = [
 			'prefix' => false,
 			'encoding' => 'utf8',
 			'timezone' => 'UTC',
-			'quoteIdentifiers' => false,
+			'quoteIdentifiers' => true,
 			'cacheMetadata' => true,
 			//'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
 		],


### PR DESCRIPTION
This should avoid the tickets we keep getting for sql errors generated due to using reserved words as field names. I don't think any amount of documentation is going to prevent them. So better to enable quoting by default and recommend in documentation to turn it off for performance.
