### PR TITLE
Fix CSS

### DIFF
--- a/webroot/css/cake.generic.css
+++ b/webroot/css/cake.generic.css
@@ -559,6 +559,7 @@ pre {
 .cake-debug-output {
 	padding: 0;
 	position: relative;
+	clear: both;
 }
 .cake-debug-output > span {
 	position: absolute;


### PR DESCRIPTION
The default layout contains two floated elements (Ex: .index and .actions) and when debug() is called in the end of the view, after one of these two classes, the browser will render .cake-debug-output over the elements making index and actions unclickable and causing the .cake-debug-output > span to go out of the yellow box.
