### PR TITLE
Use --prefer-dist option when creating project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This is an unstable repository and should be treated as an alpha.
 ## Installation
 
 1. Download [Composer](http://getcomposer.org/doc/00-intro.md) or update `composer self-update`.
-2. Run `php composer.phar create-project -s dev cakephp/app [app_name]`.
+2. Run `php composer.phar create-project --prefer-dist -s dev cakephp/app [app_name]`.
 
 If Composer is installed globally, run
-`composer create-project -s dev cakephp/app [app_name]`
+`composer create-project --prefer-dist -s dev cakephp/app [app_name]`
 
 You should now be able to visit the path to where you installed the app and see
 the setup traffic lights.


### PR DESCRIPTION
Since we use "-s dev" option, composer clones all dependencies making
the setup process quite slow and causes timeouts for many users.
