### PR TITLE
Disabling log output to stderr when using the console shell 

### DIFF
--- a/src/Console/Command/ConsoleShell.php
+++ b/src/Console/Command/ConsoleShell.php
@@ -46,6 +46,7 @@ class ConsoleShell extends Shell {
 
 		Log::drop('debug');
 		Log::drop('error');
+		$this->_io->setLoggers(false);
 		restore_error_handler();
 		restore_exception_handler();
 


### PR DESCRIPTION
It was producing duplicate output, specially for the SQL log
