### PR TITLE
Added Directory Separator DS so that other Operating Systems such as win...

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -20,7 +20,7 @@
 require __DIR__ . '/paths.php';
 
 // Use composer to load the autoloader.
-require ROOT . DS.'vendor'.DS.'autoload.php';
+require ROOT . DS . 'vendor' . DS . 'autoload.php';
 
 /**
  * Bootstrap CakePHP.


### PR DESCRIPTION
Added Directory Separator DS so that other Operating Systems such as windows path is put correctly. This fixes the autoload.php bug or warning that appears on windows
