### PR TITLE
Added Directory Seperator DS to app.default.php

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -47,8 +47,8 @@ $config = [
 		'cssBaseUrl' => 'css/',
 		'jsBaseUrl' => 'js/',
 		'paths' => [
-			'plugins' => [ROOT . '/plugins/'],
-			'templates' => [APP . 'Template/'],
+			'plugins' => [ROOT . DS . 'plugins' . DS],
+			'templates' => [APP . 'Template' . DS],
 		],
 	],
 


### PR DESCRIPTION
When the ErrorView is rendered eg when a view is missing, the full path to the view to be created is printed awkwardly for windows. This is because of the trailing forward slash that is appended on the templates or plugins array in 'app.default.php' script. 
For the experts you know what to do but can be disturbing to a novice or a tired mind.
