### PR TITLE
Create AppCell.php

### DIFF
--- a/src/View/Cell/AppCell.php
+++ b/src/View/Cell/AppCell.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace App\View\Cell;
+
+use Cake\View\Cell;
+
+/**
+ * Application Cell
+ *
+ * Add your application-wide methods in the class below, your cells
+ * will inherit them.
+ *
+ * @link http://book.cakephp.org/3.0/en/views/cells.html#the-app-cell
+ */
+class AppCell extends Cell {
+}


### PR DESCRIPTION
While working on adding Cell support to [TwigView](https://github.com/WyriHaximus/TwigView) I've noticed that not only in `AppController` the `viewClass` has to be set the to `TwigView` but also in the cells. Currently There is no `AppCell` to make this happen globally. This PR changes that. I've also included a link to the docs in case this PR gets merged.
