### PR TITLE
Populate .gitignore with more files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,5 @@
-# User specific & automatically generated files #
-#################################################
 /composer.lock
 /vendor/*
 /config/app.php
 /tmp/*
 /logs/*
-
-# IDE and editor specific files #
-#################################
-/nbproject
-.idea
-*.sublime-*
-
-# OS generated files #
-######################
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-Icon?
-ehthumbs.db
-Thumbs.db


### PR DESCRIPTION
Shouldn't `composer.lock` and `logs` be on `.gitignore`?

Also, previous versions of CakePHP had the "IDE" and "OS" parts which I pasted here (adding `*.sublime-*` for sublime dotfiles).
