### PR TITLE
Suggest cakephp/cakephp-codesniffer in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"d11wtq/boris": "1.0.*"
 	},
 	"suggest": {
-		"phpunit/phpunit": "Allows automated tests to be run without system-wide install."
+		"phpunit/phpunit": "Allows automated tests to be run without system-wide install.",
+		"cakephp/cakephp-codesniffer": "Allows to check the code against the coding standards used in CakePHP."
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
This could improve the adoption of our phpcs standard in userland code.

I didn't want to make it a `require-dev` as some people could have their own standards, which are not based on CakePHP's.
