### PR TITLE
Use DS for path separator.

### DIFF
--- a/config/paths.php
+++ b/config/paths.php
@@ -78,7 +78,7 @@ define('CACHE', TMP . 'cache' . DS);
  *
  * CakePHP should always be installed with composer, so look there.
  */
-define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
+define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp');
 
 /**
  * Path to the cake directory.


### PR DESCRIPTION
Minor correction for output display in shells on WIN

Before:

```
Current Paths:

* app: src
* root: E:\PHP\wamp\www\work\app30\app
* core: E:\PHP\wamp\www\work\app30\app/vendor/cakephp/cakephp
```

After:

```
Current Paths:

* app: src
* root: E:\PHP\wamp\www\work\app30\app
* core: E:\PHP\wamp\www\work\app30\app\vendor\cakephp\cakephp
```
