### PR TITLE
Error out when the environment lacks pcntl

### DIFF
--- a/src/Shell/ConsoleShell.php
+++ b/src/Shell/ConsoleShell.php
@@ -42,6 +42,12 @@ class ConsoleShell extends Shell {
 			$this->err('');
 			return 1;
 		}
+		if (!function_exists('pcntl_signal')) {
+			$this->err('<error>No process control functions.</error>');
+			$this->err('');
+			$this->err('You are missing the pcntl extension, the interactive console requires these.');
+			return 2;
+		}
 		$this->out('You can exit with <info>CTRL-D</info>');
 
 		Log::drop('debug');


### PR DESCRIPTION
Boris won't run on systems without pcntl - e.g. windows. This is a nicer error than a fatal error from the internals of boris.

Refs cakephp/cakephp#4481
