### PR TITLE
Reduce height of homepage header.

### DIFF
--- a/webroot/css/cake.css
+++ b/webroot/css/cake.css
@@ -285,7 +285,10 @@ pre {
 }
 
 .home header {
-  height:auto;
+  width: 100%;
+  height: 85%;
+  position: relative;
+  display: table;
 }
 
 .home h1 {
@@ -293,8 +296,9 @@ pre {
 }
 
 .home header .header-image {
-  margin: auto;
-  text-align:center;
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
 }
 
 .home header h1 {


### PR DESCRIPTION
Currently the header height is too large and on smaller resolutions the header covers the full screen. For new users it would take a while to realize you have to scroll down to get useful info.

This is what the page looks like after this change.
http://awesomescreenshot.com/0a33im5nce
