### PR TITLE
allow app tests to use core fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"App\\Test\\": "tests"
+			"App\\Test\\": "tests",
+			"Cake\\Test\\Fixture\\": "./vendor/cakephp/cakephp/tests/Fixture"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
Otherwise it'll be somewhat confusing why core.\* fixture references fail
should they be used in an app test
