### PR TITLE
Ignore plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /config/app.php
 /tmp/*
 /logs/*
+/plugins


### PR DESCRIPTION
So if we are using Composer to manage the dependancies, then shouldn't the plugins folder be ignored so that people don't commit their dependancies to their repos?

It certainly makes staging files easier as there isn't a huge list of files available to be staged from `/plugins`
