### PR TITLE
Remove the "Don't rewrite dir requests" rule

### DIFF
--- a/webroot/.htaccess
+++ b/webroot/.htaccess
@@ -1,6 +1,5 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 </IfModule>


### PR DESCRIPTION
This rule seems to [trip up users](https://github.com/cakephp/cakephp/issues/4802) more than, I think, it would the other way around.

An invented (though I think this actually comes from past experience) scenario to explain "the problem":

There is a videos controller with an index and a view action. The view action is such that a file is created in the webroot on first access:

**Index listing**:

```
url: /videos
```

Result: Videos index action invoked.

**first view request**:

```
url: /videos/view/123.mp4
```

Request passed to application, video generated, served to the client and stored in the following path:

```
filepath: app/webroot/videos/view/123.mp4
```

**second view request**:

```
url: /videos/view/123.mp4
```

Request directly served by webserver (great, much more efficient)

**Subsequent Index listing**:

```
url: /videos
```

Result:  Only considering apache, an error (server config dependent, either a file listing, a 404 or a 403).

I don't think this is what users actually expect. There is the converse argument that this rule allows users to create:

```
filepath: app/webroot/otherapplication/index.html
```

And access it as 

```
url: /otherapplication
```

But I do not think that is particularly common.

**Should we remove this rule?**

Related: #155 
