### PR TITLE
remove config-dir in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,6 @@
 	"scripts": {
 		"post-install-cmd": "App\\Console\\Installer::postInstall"
 	},
-	"config" : {
-		"bin-dir" : "bin"
-	},
 	"minimum-stability" : "dev",
 	"prefer-stable": true
 }


### PR DESCRIPTION
Use default location for vendor binaries, instead of having them copied to app/bin.
cake command will remain in app/bin. We could perhaps make the installer copy this to vendor/bin if we want to have a single place for all binaries.
