### PR TITLE
Added Port to MySQL config array

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -207,6 +207,11 @@ $config = [
 			'driver' => 'Cake\Database\Driver\Mysql',
 			'persistent' => false,
 			'host' => 'localhost',
+			/*
+			* MySQL defaults to port 3306 on most systems
+			* MySQL on MAMP uses port 8889 by default 
+			*/
+			'port' => '3306',
 			'username' => 'my_app',
 			'password' => 'secret',
 			'database' => 'my_app',
@@ -242,6 +247,7 @@ $config = [
 			'driver' => 'Cake\Database\Driver\Mysql',
 			'persistent' => false,
 			'host' => 'localhost',
+			'port' => '3306',
 			'username' => 'my_app',
 			'password' => 'secret',
 			'database' => 'test_myapp',


### PR DESCRIPTION
Added 'port' => '3306', and a comment reminding MAMP users to change to
8889
