### PR TITLE
Add file and line and more useful debug infos to error output.

### DIFF
--- a/src/Template/Error/error500.ctp
+++ b/src/Template/Error/error500.ctp
@@ -7,8 +7,28 @@ use Cake\Core\Configure;
 	<?= h($message) ?>
 </p>
 <?php
-if (Configure::read('debug')):
+if (Configure::read('debug')) :
+?>
+	<p class="info">
+		<?= h($error->getFile()); ?> in line
+		<?= h($error->getLine()); ?>
+	</p>
+<?php if (!empty($error->queryString)) : ?>
+	<p class="notice">
+		<strong>SQL Query: </strong>
+		<?= h($error->queryString); ?>
+	</p>
+<?php endif; ?>
+<?php if (!empty($error->params)) : ?>
+		<strong>SQL Query Params: </strong>
+		<?= Debugger::dump($error->params); ?>
+<?php endif; ?>
+<?php
 	echo $this->element('auto_table_warning');
 	echo $this->element('exception_stack_trace');
+
+	if (extension_loaded('xdebug')) {
+		xdebug_print_function_stack();
+	}
 endif;
 ?>


### PR DESCRIPTION
With the internal error exception there is not much to go on with the current output.

File and Line was very important for me to add in order to actually find out what the problem is and where.
Before:
![error](https://cloud.githubusercontent.com/assets/39854/5041024/fabd5c0e-6bb8-11e4-8f84-b5beee187c71.png)
After:
![error2](https://cloud.githubusercontent.com/assets/39854/5041025/fc838edc-6bb8-11e4-89e6-ab7efefb5a80.png)

Also added the xdebug stracktrace here, as has been added to other error templates as well some sql debug output in case there is some.
