### PR TITLE
don't restrict test classes to fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	"autoload-dev": {
 		"psr-4": {
 			"App\\Test\\": "tests",
-			"Cake\\Test\\Fixture\\": "./vendor/cakephp/cakephp/tests/Fixture"
+			"Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
Otherwise in the rare case of wanting to refer to any other test class - it requires custom config/head scratching.
