### PR TITLE
Read error handler config instead of consuming in bootstrap.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -103,9 +103,9 @@ ini_set('intl.default_locale', 'en_US');
  */
 $isCli = php_sapi_name() === 'cli';
 if ($isCli) {
-    (new ConsoleErrorHandler(Configure::consume('Error')))->register();
+    (new ConsoleErrorHandler(Configure::read('Error')))->register();
 } else {
-    (new ErrorHandler(Configure::consume('Error')))->register();
+    (new ErrorHandler(Configure::read('Error')))->register();
 }
 
 // Include the CLI bootstrap overrides.


### PR DESCRIPTION
This allows the config to be reused to register a new handler post
bootstrapping, by only only modifying required options and keeping the rest
same as those set in config/app.php

Use case: Crud plugin's ApiListener needs to set a custom exception render. Since in 3.x only way to change that is register a new error handler you need access to the error config so that it can only change the exception renderer class and use the rest of the settings same as what developer sets in his app config.