### PR TITLE
Update error400 and error500 error pages to use new layout.

### DIFF
--- a/src/Template/Error/error400.ctp
+++ b/src/Template/Error/error400.ctp
@@ -1,5 +1,32 @@
 <?php
 use Cake\Core\Configure;
+
+if (Configure::read('debug')):
+	$this->layout = 'dev_error';
+
+	$this->assign('title', $message);
+	$this->assign('templateName', 'error400.ctp');
+
+	$this->start('file');
+?>
+<?php if (!empty($error->queryString)) : ?>
+	<p class="notice">
+		<strong>SQL Query: </strong>
+		<?= h($error->queryString); ?>
+	</p>
+<?php endif; ?>
+<?php if (!empty($error->params)) : ?>
+		<strong>SQL Query Params: </strong>
+		<?= Debugger::dump($error->params); ?>
+<?php endif; ?>
+<?= $this->element('auto_table_warning') ?>
+<?php
+	if (extension_loaded('xdebug')):
+		xdebug_print_function_stack();
+	endif;
+
+	$this->end();
+endif;
 ?>
 <h2><?= h($message) ?></h2>
 <p class="error">
@@ -9,8 +36,3 @@ use Cake\Core\Configure;
 		"<strong>'{$url}'</strong>"
 	) ?>
 </p>
-<?php
-if (Configure::read('debug')):
-	echo $this->element('exception_stack_trace');
-endif;
-?>

--- a/src/Template/Error/error500.ctp
+++ b/src/Template/Error/error500.ctp
@@ -1,19 +1,15 @@
 <?php
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
+
+if (Configure::read('debug')):
+	$this->layout = 'dev_error';
+
+	$this->assign('title', $message);
+	$this->assign('templateName', 'error500.ctp');
+
+	$this->start('file');
 ?>
-<h2><?= __d('cake', 'An Internal Error Has Occurred') ?></h2>
-<p class="error">
-	<strong><?= __d('cake', 'Error') ?>: </strong>
-	<?= h($message) ?>
-</p>
-<?php
-if (Configure::read('debug')) :
-?>
-	<p class="info">
-		<?= h($error->getFile()); ?> in line
-		<?= h($error->getLine()); ?>
-	</p>
 <?php if (!empty($error->queryString)) : ?>
 	<p class="notice">
 		<strong>SQL Query: </strong>
@@ -26,10 +22,16 @@ if (Configure::read('debug')) :
 <?php endif; ?>
 <?php
 	echo $this->element('auto_table_warning');
-	echo $this->element('exception_stack_trace');
 
-	if (extension_loaded('xdebug')) {
+	if (extension_loaded('xdebug')):
 		xdebug_print_function_stack();
-	}
+	endif;
+
+	$this->end();
 endif;
 ?>
+<h2><?= __d('cake', 'An Internal Error Has Occurred') ?></h2>
+<p class="error">
+	<strong><?= __d('cake', 'Error') ?>: </strong>
+	<?= h($message) ?>
+</p>


### PR DESCRIPTION
Use the new layout in CakePHP core for the 'dev' version of error pages.

Related to cakephp/cakephp#5344
