### PR TITLE
Makes home h1 browser consistent

### DIFF
--- a/webroot/css/cake.css
+++ b/webroot/css/cake.css
@@ -323,7 +323,7 @@ pre {
 }
 
 .home h1 {
-  font-family: "Gill Sans", "Gill Sans MT", Calibri, sans-serif;
+  font-family: "Gill Sans MT", Calibri, sans-serif;
 }
 
 .home header .header-image {


### PR DESCRIPTION
The h1 element of the home-page looks consistent across all browsers (upper example) except in Chrome (lower example). 

![gill-sans-diff](https://cloud.githubusercontent.com/assets/230500/5338405/072446c8-7ed4-11e4-8e18-e336ec984b9f.png)

Removing the standard family seems to fix it.
