### PR TITLE
Explicitly specify paths for FileEngine and FileLog.

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -82,6 +82,7 @@ $config = [
 	'Cache' => [
 		'default' => [
 			'className' => 'File',
+			'path' => CACHE,
 		],
 
 	/**
@@ -269,11 +270,13 @@ $config = [
 	'Log' => [
 		'debug' => [
 			'className' => 'Cake\Log\Engine\FileLog',
+			'path' => LOGS,
 			'file' => 'debug',
 			'levels' => ['notice', 'info', 'debug'],
 		],
 		'error' => [
 			'className' => 'Cake\Log\Engine\FileLog',
+			'path' => LOGS,
 			'file' => 'error',
 			'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
 		],


### PR DESCRIPTION
Use of constants CACHE and LOGS is removed from cache and log packages.
Refs cakephp/cakephp#5458
