### PR TITLE
Minor update to bring back check status-colors

### DIFF
--- a/webroot/css/cake.css
+++ b/webroot/css/cake.css
@@ -353,8 +353,7 @@ pre {
 }
 
 .checks.database {
-  background-color: #8D6E65;
-  color: #fff;
+  background-color: #DFF0D8;
   padding-bottom: 10px;
   margin-bottom: 30px;
 }
@@ -374,8 +373,12 @@ pre {
 
 .home .checks .success:before {
   content: "✓";
+  color: green;
+  margin-right: 9px;
 }
 
 .home .checks .problem:before {
   content: "✘";
+  color: red;
+  margin-right: 9px;
 }


### PR DESCRIPTION
I might be mistaking but I remember the symbols used for the checks used to be colored but they now look like this:

![checks-current](https://cloud.githubusercontent.com/assets/230500/5561120/60a19030-8dbf-11e4-9ec0-b6cdf79fb8c5.png)

This PR brings the color back as shown below. 

![new](https://cloud.githubusercontent.com/assets/230500/5561122/6b2c6eee-8dbf-11e4-86ac-ffee1abc048e.png)

An alternative approach would be to stick to the first layout screenshot and only highlighting the failed checks in red like this:

![alternative](https://cloud.githubusercontent.com/assets/230500/5561130/2253bc76-8dc0-11e4-963d-7006dabb5ba5.png)

Feedback welcome
