### PR TITLE
Conditionally define DS.

### DIFF
--- a/config/paths.php
+++ b/config/paths.php
@@ -15,7 +15,9 @@
 /**
  * Use the DS to separate the directories in other defines
  */
-define('DS', DIRECTORY_SEPARATOR);
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
 
 /**
  * These defines should only be edited if you have cake installed in


### PR DESCRIPTION
My app test suites trigger notice errors on phpunit startup without this change. I think similar changes are needed in bake's test suite.

The notice error from PHPUnit isn't super helpful as you can see [here](https://travis-ci.org/cakephp/bake/jobs/45444120)
