### PR TITLE
Ignore vendor plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /config/app.php
 /tmp/*
 /logs/*
+/plugins/*

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -47,7 +47,7 @@ $config = [
         'cssBaseUrl' => 'css/',
         'jsBaseUrl' => 'js/',
         'paths' => [
-            'plugins' => [ROOT . DS . 'plugins' . DS],
+            'plugins' => [ROOT . DS . 'plugins' . DS, APP . 'Plugin' . DS],
             'templates' => [APP . 'Template' . DS],
             'locales' => [APP . 'Locale' . DS],
         ],


### PR DESCRIPTION
As discussed over IRC with a couple of you guys, here is my suggestion for a better organized app with both vendor and custom plugins:

Vendor plugins are installed by composer and thus, like their `vendor` libraries counterparts, should not be included in the application repo.

Instead, user created plugins should go in `src/Plugin` which is user land created code (so to speak).

The way this was set up, one would automatically be committing in his repo DebugKit for example when it is only a dev requirement. Maybe some docs will need to be re-adjusted, etc. but all will be (IMHO) for the better.

*If one wants to commit plugins into their repo (not really the 'right way') they still can by cloning the plugin in the `src/Plugin` or by forcing a commit of an ignored path.*