### PR TITLE
Return rather than use `$config`

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -1,5 +1,5 @@
 <?php
-$config = [
+return [
     /**
      * Debug Level:
      *

--- a/config/plugins.php
+++ b/config/plugins.php
@@ -18,6 +18,6 @@
  *
  * This is primarily used for identifying plugins in /vendor
  */
-$config = [
+return [
     'plugins' => []
 ];


### PR DESCRIPTION
It's the preferred way to load config files.