### PR TITLE
Core cache +1 year instead of +99 years to prevent negative cache lifetime

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -77,8 +77,8 @@ try {
 // for a very very long time, as we don't want
 // to refresh the cache while users are doing requests.
 if (!Configure::read('debug')) {
-    Configure::write('Cache._cake_model_.duration', '+99 years');
-    Configure::write('Cache._cake_core_.duration', '+99 years');
+    Configure::write('Cache._cake_model_.duration', '+1 years');
+    Configure::write('Cache._cake_core_.duration', '+1 years');
 }
 
 /**


### PR DESCRIPTION
+99 years is > INT_MAX on 32bit systems.