### PR TITLE
Ignore /plugins folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/vendor/*
 /config/app.php
-/tmp/*
 /logs/*
+/plugins/*
+/tmp/*
+/vendor/*


### PR DESCRIPTION
I just noticed all plugins appear in my git status which does not feel right. This PR ignores the /plugins directory and sorts entries in the .file.

Just close if not desired.