### PR TITLE
Add codeception postInstall hook

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -62,6 +62,10 @@ class Installer
         }
 
         static::setSecuritySalt($rootDir, $io);
+
+        if (class_exists('\Cake\Codeception\Console\Installer')) {
+            \Cake\Codeception\Console\Installer::customizeCodeceptionBinary($event);
+        }
     }
 
     /**


### PR DESCRIPTION
I would like to suggest adding the [Codeception post install hook](https://github.com/cakephp/codeception) into the skeleton app.

While it doesn't make any changes when the codeception plugin is not installed the developer doesn't need to add it later. It is automatically there.


Maybe a good idea would be to add also `method_exists('\Cake\Codeception\Console\Installer', 'customizeCodeceptionBinary')` for the case when the method is renamed/removed in the future.

Maybe adding the code from the plugins into the official skeleton app isn't a good idea, but since the Codeception is official plugin and is really good for testing..... What do you thing, guys?
