### PR TITLE
Add description to non-debug home exception

### DIFF
--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -20,10 +20,6 @@ use Cake\Network\Exception\NotFoundException;
 
 $this->layout = false;
 
-if (!Configure::read('debug')):
-    throw new NotFoundException();
-endif;
-
 $cakeDescription = 'CakePHP: the rapid development php framework';
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
Simply not displaying the home page when `debug` is turned off seems counter intuitive (to new users). 

Today, a user was (exactly like me some time ago) investigating routes and stuff after disabling debug and getting a blank page. 

I understand the reason behind protecting users from going live with a "forgotten" home page but think new users should be protected from confusion by either:

- pointed to the cause using some sort of message in the Exception
- removing the condition alltogether (and expect users going live to be well educated enough to disable/remove home if unneeded)
