### PR TITLE
Add PHP version check in cake.php

### DIFF
--- a/bin/cake.php
+++ b/bin/cake.php
@@ -15,6 +15,19 @@
  * @since         2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
+$minVersion = '5.4.16';
+if (file_exists('composer.json')) {
+    $composer = json_decode(file_get_contents('composer.json'));
+    if (isset($composer->require->php)) {
+        $minVersion = preg_replace('/([^0-9\.])/', '', $composer->require->php);
+    }
+}
+if (version_compare(phpversion(), $minVersion, '<')) {
+    fwrite(STDERR, sprintf("Minimum PHP version: %s. You are using: %s.\n", $minVersion, phpversion()));
+    exit(-1);
+}
+
 include dirname(__DIR__) . '/config/bootstrap.php';
 
 exit(Cake\Console\ShellDispatcher::run($argv));


### PR DESCRIPTION
This presents a friendlier error message for people accidentally
running it with 5.3.  Since this check is in bin/cake.php, it should
not affect normal web requests.

Related: cakephp/cakephp#6157

Note: No `3.1` branch yet, so this is still targeted on `master`.