### PR TITLE
Calling parent initialize on controller

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -36,6 +36,7 @@ class AppController extends Controller
      */
     public function initialize()
     {
+        parent::initialize();
         $this->loadComponent('Flash');
     }
 }


### PR DESCRIPTION
The parent method (Cake's Controller) is empty, but is a good practice to call it in case the parent starts to implement something.

Also, the doc examples also include the parent call, so give more consistency.