### PR TITLE
Enable parsing locale dates by default 

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -44,6 +44,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Plugin;
+use Cake\Database\Type;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ErrorHandler;
 use Cake\Log\Log;
@@ -193,3 +194,9 @@ if (Configure::read('debug')) {
 DispatcherFactory::add('Asset');
 DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');
+
+/**
+ * Enable default locale format parsing.
+ * This is needed for matching the auto-localized string output of Time() class when parsing dates.
+ */
+Type::build('datetime')->useLocaleParser();


### PR DESCRIPTION
to match auto localization of Time() when used as string in form inputs.
This is relevant for datetime form fields as strings, for dropdowns it is currently working fine out of the box.

Resolves https://github.com/cakephp/cakephp/pull/6351