### PR TITLE
Split comments for transport and profile up.

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -150,15 +150,11 @@ return [
     /**
      * Email configuration.
      *
-     * You can configure email transports and email delivery profiles here.
-     *
      * By defining transports separately from delivery profiles you can easily
      * re-use transport configuration across multiple profiles.
      *
      * You can specify multiple configurations for production, development and
      * testing.
-     *
-     * ### Configuring transports
      *
      * Each transport needs a `className`. Valid options are as follows:
      *
@@ -170,13 +166,6 @@ return [
      * appropriate file to src/Network/Email.  Transports should be named
      * 'YourTransport.php', where 'Your' is the name of the transport.
      *
-     * ### Configuring delivery profiles
-     *
-     * Delivery profiles allow you to predefine various properties about email
-     * messages from your application and give the settings a name. This saves
-     * duplication across your application and makes maintenance and development
-     * easier. Each profile accepts a number of keys. See `Cake\Network\Email\Email`
-     * for more information.
      */
     'EmailTransport' => [
         'default' => [
@@ -192,6 +181,16 @@ return [
         ],
     ],
 
+    /**
+     * Email delivery profiles
+     *
+     * Delivery profiles allow you to predefine various properties about email
+     * messages from your application and give the settings a name. This saves
+     * duplication across your application and makes maintenance and development
+     * easier. Each profile accepts a number of keys. See `Cake\Network\Email\Email`
+     * for more information.
+     *
+     */
     'Email' => [
         'default' => [
             'transport' => 'default',

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -165,7 +165,6 @@ return [
      * You can add custom transports (or override existing transports) by adding the
      * appropriate file to src/Network/Email.  Transports should be named
      * 'YourTransport.php', where 'Your' is the name of the transport.
-     *
      */
     'EmailTransport' => [
         'default' => [
@@ -189,7 +188,6 @@ return [
      * duplication across your application and makes maintenance and development
      * easier. Each profile accepts a number of keys. See `Cake\Network\Email\Email`
      * for more information.
-     *
      */
     'Email' => [
         'default' => [
@@ -284,7 +282,6 @@ return [
     ],
 
     /**
-     *
      * Session configuration.
      *
      * Contains an array of settings to use for session configuration. The


### PR DESCRIPTION
Hopefully with separate comments the two config keys don't seem as redundant.

Refs #253