### PR TITLE
Updated docblocks in shell scripts

### DIFF
--- a/bin/cake
+++ b/bin/cake
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 ################################################################################
 #
-# Bake is a shell script for running CakePHP bake script
+# Cake is a shell script for invoking CakePHP shell commands
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/bin/cake.bat
+++ b/bin/cake.bat
@@ -1,6 +1,6 @@
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::
-:: Bake is a shell script for running CakePHP bake script
+:: Cake is a Windows batch script for invoking CakePHP shell commands
 ::
 :: CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
 :: Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)


### PR DESCRIPTION
Diff still suggests line endings have changed but the .bat file is definitely still CRLF (edited on Windows laptop in notepad++ with line-endings visible and commited via Git with global autocrlf=true) \_(ツ)_/