### PR TITLE
Update composer.json for 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.16",
-        "cakephp/cakephp": "~3.0",
+        "cakephp/cakephp": "3.1.*-dev",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
         "cakephp/plugin-installer": "*"
@@ -14,7 +14,7 @@
     "require-dev": {
         "psy/psysh": "@stable",
         "cakephp/debug_kit": "~3.0",
-        "cakephp/bake": "~1.0"
+        "cakephp/bake": "1.1.*-dev"
     },
     "suggest": {
         "phpunit/phpunit": "Allows automated tests to be run without system-wide install.",


### PR DESCRIPTION
The 3.1 version of the app relies on bake-1.1 and cakephp-3.1. Without these requirements the new design looks wrong and the app skeleton fatally errors.