### PR TITLE
remove debug config check in home.ctp and run test against php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: php
 sudo: false
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
+  - 7.0
 
 before_script:
   - sh -c "composer require 'cakephp/cakephp-codesniffer:dev-master'"

--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -46,11 +46,7 @@ $cakeDescription = 'CakePHP: the rapid development php framework';
         </div>
     </header>
     <div id="content">
-        <?php
-        if (Configure::read('debug')):
-            Debugger::checkSecurityKeys();
-        endif;
-        ?>
+        <?php Debugger::checkSecurityKeys(); ?>
         <p id="url-rewriting-warning" style="background-color:#e32; color:#fff;display:none">
             URL rewriting is not properly configured on your server.
             1) <a target="_blank" href="http://book.cakephp.org/3.0/en/installation/url-rewriting.html" style="color:#fff;">Help me configure it</a>


### PR DESCRIPTION
This check is useless since debug = false will throw an exception https://github.com/cakephp/app/blob/master/src/Template/Pages/home.ctp#L23-L25

and run test against PHP7.0