### PR TITLE
Declare log option

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -222,6 +222,7 @@ return [
             'encoding' => 'utf8',
             'timezone' => 'UTC',
             'cacheMetadata' => true,
+            'log' => false,
 
             /**
              * Set identifier quoting to true if you are using reserved words or
@@ -259,6 +260,7 @@ return [
             'timezone' => 'UTC',
             'cacheMetadata' => true,
             'quoteIdentifiers' => false,
+            'log' => false,
             //'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
         ],
     ],


### PR DESCRIPTION
So that developers know just by looking at it, that the Datasource's file logging can be turned on.