### PR TITLE
Ignore vendor tests in code coverage reports

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	syntaxCheck="false"
-	bootstrap="./tests/bootstrap.php"
-	>
-	<php>
-		<ini name="memory_limit" value="-1"/>
-		<ini name="apc.enable_cli" value="1"/>
-	</php>
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+    bootstrap="./tests/bootstrap.php"
+    >
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="apc.enable_cli" value="1"/>
+    </php>
 
-	<!-- Add any additional test suites you want to run here -->
-	<testsuites>
-		<testsuite name="App Test Suite">
-			<directory>./tests/TestCase</directory>
-		</testsuite>
-		<!-- Add plugin test suites here. -->
-	</testsuites>
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="App Test Suite">
+            <directory>./tests/TestCase</directory>
+        </testsuite>
+        <!-- Add plugin test suites here. -->
+    </testsuites>
 
-	<!-- Setup a listener for fixtures -->
-	<listeners>
-		<listener
-		class="\Cake\TestSuite\Fixture\FixtureInjector"
-		file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-			<arguments>
-				<object class="\Cake\TestSuite\Fixture\FixtureManager" />
-			</arguments>
-		</listener>
-	</listeners>
+    <!-- Setup a listener for fixtures -->
+    <listeners>
+        <listener
+        class="\Cake\TestSuite\Fixture\FixtureInjector"
+        file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
+            <arguments>
+                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
+            </arguments>
+        </listener>
+    </listeners>
 
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,4 +30,10 @@
         </listener>
     </listeners>
 
+    <!-- Ignore vendor tests in code coverage reports -->
+    <filter>
+        <blacklist>
+            <directory suffix=".php">./vendor/</directory>
+        </blacklist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
I think this makes sense as the default config.