### PR TITLE
update requires for 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://api.travis-ci.org/cakephp/app.png)](https://travis-ci.org/cakephp/app)
 [![License](https://poser.pugx.org/cakephp/app/license.svg)](https://packagist.org/packages/cakephp/app)
 
-A skeleton for creating applications with [CakePHP](http://cakephp.org) 3.0.
+A skeleton for creating applications with [CakePHP](http://cakephp.org) 3.x.
 
 The framework source code can be found here: [cakephp/cakephp](https://github.com/cakephp/cakephp).
 

--- a/composer.json
+++ b/composer.json
@@ -6,15 +6,15 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.16",
-        "cakephp/cakephp": "3.1.*-dev",
+        "cakephp/cakephp": "~3.1",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
         "cakephp/plugin-installer": "*"
     },
     "require-dev": {
         "psy/psysh": "@stable",
-        "cakephp/debug_kit": "3.2.x-dev",
-        "cakephp/bake": "1.1.*-dev"
+        "cakephp/debug_kit": "~3.2",
+        "cakephp/bake": "~1.1"
     },
     "suggest": {
         "phpunit/phpunit": "Allows automated tests to be run without system-wide install.",


### PR DESCRIPTION
I created a new cakephp project with `composer create-project --prefer-dist cakephp/app`, but composer downloaded dev libraries for:
- cakephp/cakephp (3.1.x-dev 059fabb)
- cakephp/debug_kit (3.2.x-dev 4d7449a)
- cakephp/bake (1.1.x-dev 68d4c0f)

Should `composer create-project` install by default the last stable cakephp 3.1 version (and all libraries tagged to versions for 3.1) or should it install dev libraries with last changes ?

