### PR TITLE
Change min. stability to "stable".

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
         "post-install-cmd": "App\\Console\\Installer::postInstall",
         "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
With the stable release of cakephp 3.1 and related projects it's better to use stable packages.