### PR TITLE
Reduce the number of commented indexes in the i18n sql.

### DIFF
--- a/config/schema/i18n.sql
+++ b/config/schema/i18n.sql
@@ -8,20 +8,13 @@
 # MIT License (http://www.opensource.org/licenses/mit-license.php)
 
 CREATE TABLE i18n (
-	id int(10) NOT NULL auto_increment,
-	locale varchar(6) NOT NULL,
-	model varchar(255) NOT NULL,
-	foreign_key int(10) NOT NULL,
-	field varchar(255) NOT NULL,
-	content mediumtext,
-	PRIMARY KEY	(id),
-#	UNIQUE INDEX I18N_LOCALE_FIELD(locale, model, foreign_key, field),
-#	INDEX I18N_LOCALE_ROW(locale, model, foreign_key),
-#	INDEX I18N_LOCALE_MODEL(locale, model),
-#	INDEX I18N_FIELD(model, foreign_key, field),
-#	INDEX I18N_ROW(model, foreign_key),
-	INDEX locale (locale),
-	INDEX model (model),
-	INDEX row_id (foreign_key),
-	INDEX field (field)
+    id int NOT NULL auto_increment,
+    locale varchar(6) NOT NULL,
+    model varchar(255) NOT NULL,
+    foreign_key int(10) NOT NULL,
+    field varchar(255) NOT NULL,
+    content text,
+    PRIMARY KEY (id),
+    UNIQUE INDEX I18N_LOCALE_FIELD(locale, model, foreign_key, field),
+    INDEX I18N_FIELD(model, foreign_key, field)
 );


### PR DESCRIPTION
This syncs the repo schema with the documentation. Most of the removed indexes were not necessary as they were covered by other index prefixes, or were columns that are not filtered on individually.

Refs #298