### PR TITLE
Update phpunit.xml.dist to include code coverage white list

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,5 +35,8 @@
         <blacklist>
             <directory suffix=".php">./vendor/</directory>
         </blacklist>
+        <whitelist>
+            <directory suffix=".php">./tests/TestCase/</directory>
+        </whitelist>
     </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,6 +37,7 @@
         </blacklist>
         <whitelist>
             <directory suffix=".php">./tests/TestCase/</directory>
+            <directory suffix=".php">./src/</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
When attempting to use the default phpunit configuration and generating code coverage I received the error "No whitelist configured, no code coverage will be generated". This change adds the the TestCase folder to the white list so that code coverage can be successfully generated.

phpunit 5.0.9