### PR TITLE
Immutable time

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.16",
-        "cakephp/cakephp": "~3.1",
+        "cakephp/cakephp": "~3.2",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
         "cakephp/plugin-installer": "*"

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -198,6 +198,15 @@ DispatcherFactory::add('ControllerFactory');
 /**
  * Enable default locale format parsing.
  * This is needed for matching the auto-localized string output of Time() class when parsing dates.
+ *
+ * Also enable immutable time objects in the ORM.
  */
-Type::build('date')->useLocaleParser();
-Type::build('datetime')->useLocaleParser();
+Type::build('time')
+    ->useImmutable()
+    ->useLocaleParser();
+Type::build('date')
+    ->useImmutable()
+    ->useLocaleParser();
+Type::build('datetime')
+    ->useImmutable()
+    ->useLocaleParser();


### PR DESCRIPTION
Going to immutable objects for new apps will let us remove mutable time objects as a default in 4.x.

Refs cakephp/cakephp#7713