### PR TITLE
Add comment on cache duration override in bootstrap

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -89,6 +89,7 @@ return [
         /**
          * Configure the cache used for general framework caching.
          * Translation cache files are stored with this configuration.
+         * Duration will be set to '+1 year' in bootstrap.php when debug = false
          */
         '_cake_core_' => [
             'className' => 'File',
@@ -102,6 +103,7 @@ return [
          * Configure the cache for model and datasource caches. This cache
          * configuration is used to store schema descriptions, and table listings
          * in connections.
+         * Duration will be set to '+1 year' in bootstrap.php when debug = false
          */
         '_cake_model_' => [
             'className' => 'File',


### PR DESCRIPTION
There is no information in the app.default.php that the values specified for the core cache files will be overridden in bootstrap.php

I was very confused, that there was no hint in the cake book, nor in the comments. I had to step debug through the whole caching to find out why the settings in the bootstrap.php are overwritten.