### PR TITLE
Displaying the error message in PHP 7

### DIFF
--- a/src/Template/Error/error500.ctp
+++ b/src/Template/Error/error500.ctp
@@ -20,6 +20,10 @@ if (Configure::read('debug')):
         <strong>SQL Query Params: </strong>
         <?= Debugger::dump($error->params) ?>
 <?php endif; ?>
+<?php if ($error instanceof Error) : ?>
+        <strong>Error in: </strong>
+        <?= sprintf('%s, line %s', str_replace(ROOT, 'ROOT', $error->getFile()), $error->getLine()) ?>
+<?php endif; ?>
 <?php
     echo $this->element('auto_table_warning');
 


### PR DESCRIPTION
Otherwise the error page looked entirely without the cause of the error