### PR TITLE
Update Installer.php

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -128,8 +128,8 @@ class Installer
     {
         // Change the permissions on a path and output the results.
         $changePerms = function ($path, $perms, $io) {
-            // Get current permissions in decimal format so we can bitmask it.
-            $currentPerms = octdec(substr(sprintf('%o', fileperms($path)), -4));
+            // Get permission bits from stat(2) result.
+            $currentPerms = fileperms($path) & 0777;
             if (($currentPerms & $perms) == $perms) {
                 return;
             }


### PR DESCRIPTION
no need to call octdec to extract permission bits with substr

[stat(2)](http://linux.die.net/man/2/stat) last three octets are 777 (aka user-group-other),
the other bits don't matter (i.e 1000 for o+t and 2000 for g+s, etc)