### PR TITLE
Add hint for fullBaseUrl in CLI environments

### DIFF
--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -23,7 +23,7 @@ use Cake\Core\Plugin;
 
 // Set the fullBaseUrl to some doubtful/useful default as it cannot be known
 // from e.g. $_SERVER['HOST_NAME'] with no webserver involved (cli-sapi).
-// This is especially very usefull when sending email from the shell.
+// This is especially very usefull when sending email from shells.
 //Configure::write('App.fullBaseUrl', php_uname('n'));
 
 // Set logs to different files so they don't have permission conflicts.

--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -21,6 +21,11 @@ use Cake\Core\Plugin;
  * be put here.
  */
 
+// Set the fullBaseUrl to some doubtful/useful default as it cannot be known
+// from e.g. $_SERVER['HOST_NAME'] with no webserver involved (cli-sapi).
+// This is especially very usefull when sending email from the shell.
+//Configure::write('App.fullBaseUrl', php_uname('n'));
+
 // Set logs to different files so they don't have permission conflicts.
 Configure::write('Log.debug.file', 'cli-debug');
 Configure::write('Log.error.file', 'cli-error');

--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -23,7 +23,7 @@ use Cake\Core\Plugin;
 
 // Set the fullBaseUrl to some doubtful/useful default as it cannot be known
 // from e.g. $_SERVER['HOST_NAME'] with no webserver involved (cli-sapi).
-// This is especially very usefull when sending email from shells.
+// This is especially very useful when sending email from shells.
 //Configure::write('App.fullBaseUrl', php_uname('n'));
 
 // Set logs to different files so they don't have permission conflicts.


### PR DESCRIPTION
Whenever a URL is generated from within a shell context, the fullBaseUrl cannot be known (automatically), like from the $_SERVER['HOST_NAME'],
which leads to problems when e.g. sending emails...
The information and documentation on how to "fix" this is hard to find and hinting in the configuration file for this specific case seems reasonable.