### PR TITLE
Remove an empty line output

### DIFF
--- a/bin/cake.bat
+++ b/bin/cake.bat
@@ -17,7 +17,6 @@
 
 :: In order for this script to work as intended, the cake\console\ folder must be in your PATH
 
-@echo.
 @echo off
 
 SET app=%0


### PR DESCRIPTION
PR for #310 

Prevent to output an empty line before the XML declaration when a command is run using `--xml` option.