### PR TITLE
Making the app repo usable with cake 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
         "post-install-cmd": "App\\Console\\Installer::postInstall",
         "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }


### PR DESCRIPTION
This should be reverted before cake 3.2 is marked stable