### PR TITLE
Update home.ctp

### DIFF
--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -22,7 +22,7 @@ use Cake\Network\Exception\ForbiddenException;
 $this->layout = false;
 
 if (!Configure::read('debug')):
-    Log::write('warning', 'Pages::display(\'home\'); is only accessible if debug is set to true.');
+    Log::write('warning', 'PagesController::display(\'home\'); is only accessible if debug is set to true.');
     throw new ForbiddenException();
 endif;
 

--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -22,7 +22,7 @@ use Cake\Network\Exception\ForbiddenException;
 $this->layout = false;
 
 if (!Configure::read('debug')):
-    Log::write('warning', 'Pages/home is only accessible if debug is set to true.');
+    Log::write('warning', 'Pages::display(\'home\'); is only accessible if debug is set to true.');
     throw new ForbiddenException();
 endif;
 

--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -16,12 +16,14 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\Debugger;
-use Cake\Network\Exception\NotFoundException;
+use Cake\Log\Log;
+use Cake\Network\Exception\ForbiddenException;
 
 $this->layout = false;
 
 if (!Configure::read('debug')):
-    throw new NotFoundException();
+    Log::write('warning', 'Pages/home is only accessible if debug is set to true.');
+    throw new ForbiddenException();
 endif;
 
 $cakeDescription = 'CakePHP: the rapid development php framework';


### PR DESCRIPTION
Please review the error message itself, written to errors.log, flagged as warning.
Could you think of a more concise English sentence pointing at that controller/action/template?
Maybe Pages::display/home ?

Ref: https://github.com/cakephp/app/issues/43#issuecomment-38471491
Ref: https://github.com/cakephp/app/issues/43#issuecomment-38473872

Note: I'd actually include an error message, because where is the security issue here with being transparent?