### PR TITLE
Make it even clearer for beginners to replace home.ctp

### DIFF
--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -47,6 +47,11 @@ $cakeDescription = 'CakePHP: the rapid development php framework';
     </header>
     <div id="content">
         <div class="row">
+            <div class="row">
+                <div class="columns large-12 ctp-warning checks">
+                    <p>Please be aware that this page will not be shown if you turn off debug mode unless you disable the NotFoundException in src/Template/Pages/home.ctp.</p>
+                </div>
+            </div>
             <?php Debugger::checkSecurityKeys(); ?>
             <div id="url-rewriting-warning" class="columns large-12 url-rewriting checks">
                 <p class="problem">URL rewriting is not properly configured on your server.</p>

--- a/webroot/css/cake.css
+++ b/webroot/css/cake.css
@@ -319,6 +319,11 @@ pre {
     margin-top:50px;
 }
 
+.checks.ctp-warning {
+    background-color: #ff5555;
+    padding-bottom: 10px;
+}
+
 .checks.url-rewriting {
     background-color: #F0F0F0;
     display: none;


### PR DESCRIPTION
Incremental improvement to help out new users even better by informing them through newly added `ctp-warning` splash screen row. Refs https://github.com/cakephp/app/pull/319#issuecomment-169300334

![really-help](https://cloud.githubusercontent.com/assets/230500/12154874/6a97a810-b4c2-11e5-8580-50f5107ca2ea.png)
