### PR TITLE
More graceful error rendering.

### DIFF
--- a/src/Template/Error/error400.ctp
+++ b/src/Template/Error/error400.ctp
@@ -2,6 +2,8 @@
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
+$this->layout = 'error';
+
 if (Configure::read('debug')):
     $this->layout = 'dev_error';
 

--- a/src/Template/Error/error500.ctp
+++ b/src/Template/Error/error500.ctp
@@ -2,6 +2,8 @@
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
+$this->layout = 'error';
+
 if (Configure::read('debug')):
     $this->layout = 'dev_error';
 


### PR DESCRIPTION
I think the default error templates should switch from default to error layout.
It took me a while to track down the issue because no logs and no debug output of any kind is emitted in the case when the default.ctp cannot render.
But this can happen actually in almost every app, because the normal dispatching cycle is broken and the view most likely does not have all data available it needs to properly render the default layout.

Result: Always 500 display, even for a simple 400.

In my case a helper call in an element needed sth from a components beforeRender, which never got executed because of the RecordNotFoundException going straight to the rendering.
Thus it is not sane/safe to try to render a layout that by design in most cases cannot safely continue to render.