### PR TITLE
Support starting shells using a symlink

### DIFF
--- a/bin/cake
+++ b/bin/cake
@@ -36,5 +36,11 @@ canonicalize() {
 CONSOLE=$(dirname -- "$(canonicalize "$0")")
 APP=$(dirname "$CONSOLE")
 
-exec php "$CONSOLE"/cake.php "$@"
+if [ $0 != 'cake' ]
+then
+    exec php "$CONSOLE"/cake.php $(basename $0) "$@"
+else
+    exec php "$CONSOLE"/cake.php "$@"
+fi
+
 exit


### PR DESCRIPTION
This change makes it possible to for example add a symlink called `bake` pointing to `bake` to the bin directory which when executed runs the bake shell.

I've not used it yet but it might be useful to someone. I might use this for `server` for example.