### PR TITLE
Encourage to replace home.ctp with own version

### DIFF
--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -21,10 +21,10 @@ use Cake\Network\Exception\NotFoundException;
 $this->layout = false;
 
 if (!Configure::read('debug')):
-    throw new NotFoundException('Please replace src/View/Pages/home.ctp with your own version.');
+    throw new NotFoundException('Please replace src/Template/Pages/home.ctp with your own version.');
 endif;
 
-$cakeDescription = 'CakePHP: the rapid development PHP framework';
+$cakeDescription = 'CakesrcPHP: the rapid development PHP framework';
 ?>
 <!DOCTYPE html>
 <html>
@@ -48,7 +48,7 @@ $cakeDescription = 'CakePHP: the rapid development PHP framework';
     <div id="content">
         <div class="row">
             <div class="columns large-12 ctp-warning checks">
-                Please be aware that this page will not be shown if you turn off debug mode unless you replace src/View/Pages/home.ctp with your own version.
+                Please be aware that this page will not be shown if you turn off debug mode unless you replace src/Template/Pages/home.ctp with your own version.
             </div>
             <?php Debugger::checkSecurityKeys(); ?>
             <div id="url-rewriting-warning" class="columns large-12 url-rewriting checks">

--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -24,7 +24,7 @@ if (!Configure::read('debug')):
     throw new NotFoundException('Please replace src/Template/Pages/home.ctp with your own version.');
 endif;
 
-$cakeDescription = 'CakesrcPHP: the rapid development PHP framework';
+$cakeDescription = 'CakePHP: the rapid development PHP framework';
 ?>
 <!DOCTYPE html>
 <html>

--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -21,7 +21,7 @@ use Cake\Network\Exception\NotFoundException;
 $this->layout = false;
 
 if (!Configure::read('debug')):
-    throw new NotFoundException('Please replace Pages/home.ctp with your own version.');
+    throw new NotFoundException('Please replace src/View/Pages/home.ctp with your own version.');
 endif;
 
 $cakeDescription = 'CakePHP: the rapid development PHP framework';
@@ -48,7 +48,7 @@ $cakeDescription = 'CakePHP: the rapid development PHP framework';
     <div id="content">
         <div class="row">
             <div class="columns large-12 ctp-warning checks">
-                Please be aware that this page will not be shown if you turn off debug mode unless you disable the NotFoundException in src/Template/Pages/home.ctp.
+                Please be aware that this page will not be shown if you turn off debug mode unless you replace src/View/Pages/home.ctp with your own version.
             </div>
             <?php Debugger::checkSecurityKeys(); ?>
             <div id="url-rewriting-warning" class="columns large-12 url-rewriting checks">


### PR DESCRIPTION
... instead of specify some Exceptions some newbies won't get (those knowing the framework don't need this warning anyway).