### PR TITLE
Don't use locale parsing by default.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -206,17 +206,15 @@ DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');
 
 /**
- * Enable default locale format parsing.
- * This is needed for matching the auto-localized string output of Time() class when parsing dates.
+ * Enable immutable time objects in the ORM.
  *
- * Also enable immutable time objects in the ORM.
+ * You can enable default locale format parsing. By adding calls
+ * to `useLocaleParser()`. This enables the automatic conversion of
+ * locale specific date formats.
  */
 Type::build('time')
-    ->useImmutable()
-    ->useLocaleParser();
+    ->useImmutable();
 Type::build('date')
-    ->useImmutable()
-    ->useLocaleParser();
+    ->useImmutable();
 Type::build('datetime')
-    ->useImmutable()
-    ->useLocaleParser();
+    ->useImmutable();


### PR DESCRIPTION
While this is a pretty neat feature. It causes new users a bunch of grief as they try to accept SQL date formats in en-US locales.

Refs cakephp/cakephp#8593