### PR TITLE
Change varchar to char

### DIFF
--- a/config/schema/sessions.sql
+++ b/config/schema/sessions.sql
@@ -6,7 +6,7 @@
 # MIT License (http://www.opensource.org/licenses/mit-license.php)
 
 CREATE TABLE sessions (
-  id varchar(40) NOT NULL default '',
+  id char(40) NOT NULL,
   data text,
   expires INT(11) NOT NULL,
   PRIMARY KEY  (id)


### PR DESCRIPTION
Updates the schema for sessions to use `char(40)` for the primary ID. Also removed the default since this column can not be empty. It has to have the session ID from PHP.

closes #383 