### PR TITLE
Micro optimization

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -20,6 +20,7 @@
 
 use Cake\Core\Plugin;
 use Cake\Routing\RouteBuilder;
+use Cake\Routing\Route\DashedRouted;
 use Cake\Routing\Router;
 
 /**
@@ -40,7 +41,7 @@ use Cake\Routing\Router;
  * `:action` markers.
  *
  */
-Router::defaultRouteClass('DashedRoute');
+Router::defaultRouteClass(DashedRoute::class);
 
 Router::scope('/', function (RouteBuilder $routes) {
     /**


### PR DESCRIPTION
Some time ago, when profiling my app, I noticed that using short class name for the default route class would call the autoloader as many times as you  have routes. In a big app, that have be a couple hundred extra function calls.

This removes that case