### PR TITLE
Add PSR7 Skeleton code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,13 @@
         "cakephp/cakephp": "~3.2",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
-        "cakephp/plugin-installer": "*"
+        "cakephp/plugin-installer": "*",
+        "markstory/cakephp-spekkoek": "dev-master"
     },
     "require-dev": {
         "psy/psysh": "@stable",
         "cakephp/debug_kit": "~3.2",
+        "phpunit/phpunit": "*",
         "cakephp/bake": "~1.1"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,14 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": "~3.2",
+        "cakephp/cakephp": "dev-3.next as 3.3.0-dev",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
-        "cakephp/plugin-installer": "*",
-        "markstory/cakephp-spekkoek": "dev-master"
+        "cakephp/plugin-installer": "*"
     },
     "require-dev": {
         "psy/psysh": "@stable",
         "cakephp/debug_kit": "~3.2",
-        "phpunit/phpunit": "*",
         "cakephp/bake": "~1.1"
     },
     "suggest": {
@@ -38,6 +36,6 @@
         "post-create-project-cmd": "App\\Console\\Installer::postInstall",
         "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -199,13 +199,6 @@ if (Configure::read('debug')) {
 }
 
 /**
- * Connect middleware/dispatcher filters.
- */
-DispatcherFactory::add('Asset');
-DispatcherFactory::add('Routing');
-DispatcherFactory::add('ControllerFactory');
-
-/**
  * Enable immutable time objects in the ORM.
  *
  * You can enable default locale format parsing by adding calls

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,49 @@
+<?php
+namespace App;
+
+use Cake\Http\BaseApplication;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Routing\Middleware\AssetMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic, and middleware layers you
+ * want to use in your application.
+ */
+class Application extends BaseApplication
+{
+    /**
+     * Load all the application configuration and bootstrap logic.
+     *
+     * You can include any other files your application needs to bootstrap
+     * in a web context here.
+     *
+     * @return void
+     */
+    public function bootstrap()
+    {
+        require_once $this->configDir . '/bootstrap.php';
+    }
+
+    /**
+     * Setup the middleware your application will use.
+     *
+     * @param \Cake\Http\MiddlewareStack $middleware The middleware stack to setup.
+     * @return \Cake\Http\MiddlewareStack The updated middleware.
+     */
+    public function middleware($middleware)
+    {
+        // Catch any exceptions in the lower layers,
+        // and make an error page/response
+        $middleware->push(new ErrorHandlerMiddleware());
+
+        // Handle plugin/theme assets like CakePHP normally does.
+        $middleware->push(new AssetMiddleware());
+
+        // Apply routing
+        $middleware->push(new RoutingMiddleware());
+        return $middleware;
+    }
+}

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,4 +1,17 @@
 <?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link      http://cakephp.org CakePHP(tm) Project
+ * @since     3.3.0
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace App;
 
 use Cake\Http\BaseApplication;

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -24,14 +24,14 @@ if (php_sapi_name() === 'cli-server') {
         return false;
     }
 }
-require dirname(__DIR__) . '/config/bootstrap.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Cake\Network\Request;
-use Cake\Network\Response;
-use Cake\Routing\DispatcherFactory;
+use Cake\Http\Server;
+use App\Application;
 
-$dispatcher = DispatcherFactory::create();
-$dispatcher->dispatch(
-    Request::createFromGlobals(),
-    new Response()
-);
+// Bind your application to the server.
+$server = new Server(new Application(dirname(__DIR__) . '/config'));
+
+// Run the request/response through the application
+// and emit the response.
+$server->emit($server->run());


### PR DESCRIPTION
This updates the app skeleton to use the new `Cake\Http` library instead of using DispatcherFilters. While the new library is optional for existing applications, I think its useful to start new folks off on the path we'd like to go down in the future.

Refs cakephp/cakephp#6960