### PR TITLE
Revert defaultOutputTimezone() changes.

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -15,9 +15,7 @@ return [
      * Configure basic information about the application.
      *
      * - namespace - The namespace to find app classes under.
-     * - defaultLocale - The default locale for translation, formatting currencies and numbers, date and time,
-     *   processed in boostrap.php
-     * - defaultOutputTimezone - The default output timezone processed in bootstrap.php
+     * - defaultLocale - The default locale for translation, formatting currencies and numbers, date and time.
      * - encoding - The encoding used for HTML + database connections.
      * - base - The base directory the app resides in. If false this
      *   will be auto detected.
@@ -42,7 +40,6 @@ return [
         'namespace' => 'App',
         'encoding' => env('APP_ENCODING', 'UTF-8'),
         'defaultLocale' => env('APP_DEFAULT_LOCALE', 'en_US'),
-        'defaultOutputTimezone' => env('APP_DEFAULT_OUTPUT_TIMEZONE', 'UTC'),
         'base' => false,
         'dir' => 'src',
         'webroot' => 'webroot',

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -57,8 +57,6 @@ use Cake\Core\Plugin;
 use Cake\Database\Type;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ErrorHandler;
-use Cake\I18n\FrozenTime;
-use Cake\I18n\Time;
 use Cake\Log\Log;
 use Cake\Mailer\Email;
 use Cake\Network\Request;
@@ -81,18 +79,14 @@ try {
     exit($e->getMessage() . "\n");
 }
 
-/**
- * Load an environment local configuration file.
- * You can use a file like app_local.php to provide local overrides to your
- * shared configuration.
- */
+// Load an environment local configuration file.
+// You can use a file like app_local.php to provide local overrides to your
+// shared configuration.
 //Configure::load('app_local', 'default');
 
-/**
- * When debug = false the metadata cache should last
- * for a very very long time, as we don't want
- * to refresh the cache while users are doing requests.
- */
+// When debug = false the metadata cache should last
+// for a very very long time, as we don't want
+// to refresh the cache while users are doing requests.
 if (!Configure::read('debug')) {
     Configure::write('Cache._cake_model_.duration', '+1 years');
     Configure::write('Cache._cake_core_.duration', '+1 years');
@@ -103,12 +97,6 @@ if (!Configure::read('debug')) {
  * choice but using UTC makes time calculations / conversions easier.
  */
 date_default_timezone_set('UTC');
-
-/**
- * Sets the default output timezones.
- */
-Time::setDefaultOutputTimezone(Configure::read('App.defaultOutputTimezone'));
-FrozenTime::setDefaultOutputTimezone(Configure::read('App.defaultOutputTimezone'));
 
 /**
  * Configure the mbstring extension to use the correct encoding.
@@ -131,9 +119,7 @@ if ($isCli) {
     (new ErrorHandler(Configure::read('Error')))->register();
 }
 
-/**
- * Include the CLI bootstrap overrides.
- */
+// Include the CLI bootstrap overrides.
 if ($isCli) {
     require __DIR__ . '/bootstrap_cli.php';
 }
@@ -187,11 +173,12 @@ Request::addDetector('tablet', function ($request) {
  * Custom Inflector rules, can be set to correctly pluralize or singularize
  * table, model, controller names or whatever other string is passed to the
  * inflection functions.
+ *
+ * Inflector::rules('plural', ['/^(inflect)or$/i' => '\1ables']);
+ * Inflector::rules('irregular', ['red' => 'redlings']);
+ * Inflector::rules('uninflected', ['dontinflectme']);
+ * Inflector::rules('transliteration', ['/å/' => 'aa']);
  */
-//Inflector::rules('plural', ['/^(inflect)or$/i' => '\1ables']);
-//Inflector::rules('irregular', ['red' => 'redlings']);
-//Inflector::rules('uninflected', ['dontinflectme']);
-//Inflector::rules('transliteration', ['/å/' => 'aa']);
 
 /**
  * Plugins need to be loaded manually, you can either load them one by one or all of them in a single call
@@ -205,9 +192,8 @@ Request::addDetector('tablet', function ($request) {
 
 Plugin::load('Migrations');
 
-/*
- * DebugKit should only be loaded in development mode and not on a production system.
- */
+// Only try to load DebugKit in development mode
+// Debug Kit should not be installed on a production system
 if (Configure::read('debug')) {
     Plugin::load('DebugKit', ['bootstrap' => true]);
 }


### PR DESCRIPTION
I'm reverting this off after the discussion in cakephp/cakephp#8948 which has has pointed towards an implementation in TimeHelper being safer and creating more transparent behavior.

Revert "Merge pull request #363 from ionas/datetimezone"

This reverts commit 1ee606746550c7566b7fefd2761bca2c496e5689, reversing changes made to 5cd0b0bb1c2dbb5f0cb356a89bd70a64bacaa783.