### PR TITLE
Don't load composer's autoloader in config/bootstrap.php.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -34,9 +34,6 @@ if (!extension_loaded('mbstring')) {
  */
 require __DIR__ . '/paths.php';
 
-// Use composer to load the autoloader.
-require ROOT . DS . 'vendor' . DS . 'autoload.php';
-
 /**
  * Bootstrap CakePHP.
  *


### PR DESCRIPTION
It's now already loaded in webroot/index.php.