### PR TITLE
Include composer's autoloader for cakephp console.

### DIFF
--- a/bin/cake.php
+++ b/bin/cake.php
@@ -28,6 +28,7 @@ if (version_compare(phpversion(), $minVersion, '<')) {
     exit(-1);
 }
 
+require dirname(__DIR__) . '/vendor/autoload.php';
 include dirname(__DIR__) . '/config/bootstrap.php';
 
 exit(Cake\Console\ShellDispatcher::run($argv));


### PR DESCRIPTION
This is necessary as including autoloader was removed from bootstrap in 7930e7711c5697a8cda07108d5497d11e5ca7a05