### PR TITLE
Use Security::randomBytes() for salt generation.

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -14,6 +14,7 @@
  */
 namespace App\Console;
 
+use Cake\Utility\Security;
 use Composer\Script\Event;
 use Exception;
 
@@ -174,7 +175,7 @@ class Installer
         $config = $dir . '/config/app.php';
         $content = file_get_contents($config);
 
-        $newKey = hash('sha256', $dir . php_uname() . microtime(true));
+        $newKey = hash('sha256', Security::randomBytes(64));
         $content = str_replace('__SALT__', $newKey, $content, $count);
 
         if ($count == 0) {


### PR DESCRIPTION
It s hypothetically possible for someone to know parts of the data that is used to generate the salt value. This could potentially make guessing the salt value easier.

Refs cakephp/cakephp#9155