### PR TITLE
Charge order of Plugins loaded

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -204,10 +204,10 @@ Type::build('datetime')
  *
  */
 
-Plugin::load('Migrations');
-
 // Only try to load DebugKit in development mode
 // Debug Kit should not be installed on a production system
 if (Configure::read('debug')) {
     Plugin::load('DebugKit', ['bootstrap' => true]);
 }
+
+Plugin::load('Migrations');


### PR DESCRIPTION
This will look nicer when plugins are being added via `cake bake plugin` or `composer require`.
Followup to https://github.com/cakephp/app/pull/407