### PR TITLE
Update only to core bugfix versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": "~3.3",
+        "cakephp/cakephp": "3.3.*",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
         "cakephp/plugin-installer": "*"


### PR DESCRIPTION
Before this change the core would be updated to new minor version release too
but based on past experience it rarely goes smoothly and causes grief to users.
So only updating to bugfix versions is a better default.