### PR TITLE
Allow for HTML context.

### DIFF
--- a/src/Template/Element/Flash/default.ctp
+++ b/src/Template/Element/Flash/default.ctp
@@ -3,5 +3,8 @@ $class = 'message';
 if (!empty($params['class'])) {
     $class .= ' ' . $params['class'];
 }
+if (!isset($params['escape']) || $params['escape'] !== false) {
+    $message = h($message);
+}
 ?>
-<div class="<?= h($class) ?>" onclick="this.classList.add('hidden');"><?= h($message) ?></div>
+<div class="<?= h($class) ?>" onclick="this.classList.add('hidden');"><?= $message ?></div>

--- a/src/Template/Element/Flash/error.ctp
+++ b/src/Template/Element/Flash/error.ctp
@@ -1,1 +1,6 @@
-<div class="message error" onclick="this.classList.add('hidden');"><?= h($message) ?></div>
+<?php
+if (!isset($params['escape']) || $params['escape'] !== false) {
+    $message = h($message);
+}
+?>
+<div class="message error" onclick="this.classList.add('hidden');"><?= $message ?></div>

--- a/src/Template/Element/Flash/success.ctp
+++ b/src/Template/Element/Flash/success.ctp
@@ -1,1 +1,6 @@
-<div class="message success" onclick="this.classList.add('hidden')"><?= h($message) ?></div>
+<?php
+if (!isset($params['escape']) || $params['escape'] !== false) {
+    $message = h($message);
+}
+?>
+<div class="message success" onclick="this.classList.add('hidden')"><?= $message ?></div>


### PR DESCRIPTION
The default templates should allow for HTML context, e.g.
```php
$this->Flash->info('<b>' . h($highlight) . '</b> ' . h($message), ['params' => ['escape' => false]]);
```