### PR TITLE
Use ::class consistently in routes config.

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -72,7 +72,7 @@ Router::scope('/', function (RouteBuilder $routes) {
      * You can remove these routes once you've connected the
      * routes you want in your application.
      */
-    $routes->fallbacks('DashedRoute');
+    $routes->fallbacks(DashedRoute::class);
 });
 
 /**


### PR DESCRIPTION
For 3.x (current) it the usage should be reverted?