### PR TITLE
Add ErrorController.

### DIFF
--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.3.4
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace App\Controller;
+
+use Cake\Event\Event;
+
+/**
+ * Error Handling Controller
+ *
+ * Controller used by ExceptionRenderer to render error responses.
+ */
+class ErrorController extends AppController
+{
+    /**
+     * Initialization hook method.
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+        $this->loadComponent('RequestHandler');
+    }
+
+    /**
+     * beforeRender callback.
+     *
+     * @param \Cake\Event\Event $event Event.
+     * @return void
+     */
+    public function beforeRender(Event $event)
+    {
+        parent::beforeRender($event);
+
+        $this->viewBuilder()->templatePath('Error');
+    }
+}

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -34,6 +34,16 @@ class ErrorController extends AppController
     }
 
     /**
+     * beforeFilter callback.
+     *
+     * @param \Cake\Event\Event $event Event.
+     * @return void
+     */
+    public function beforeFilter(Event $event)
+    {
+    }
+
+    /**
      * beforeRender callback.
      *
      * @param \Cake\Event\Event $event Event.


### PR DESCRIPTION
This ensures settings done in AppController are used when generating error responses too.

I have seen numerous users on IRC/Slack struggle to figure out why the setting they have done in `AppController` don't affect their error pages since they don't realize that by default the core's `ErrorController` is used which extends `Controller` not `AppController`. Most go down the wrong path of either trying to use custom error handler or exception renderer. So perhaps the docs need improving too. Regardless having a `ErrorController` in app itself should save newbies some hair pulling.