### PR TITLE
Fix word break and alignment for longer content

### DIFF
--- a/webroot/css/cake.css
+++ b/webroot/css/cake.css
@@ -575,3 +575,8 @@ div.message.hidden {
     margin-bottom: 10px;
     border-bottom: 0px;
 }
+
+table td {
+    vertical-align: top;
+    word-break: break-all;
+}


### PR DESCRIPTION
Resolves https://github.com/cakephp/app/issues/437

Better defaults to work out of the box with all kinds of content.