### PR TITLE
Fix the order for combined check script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
         "post-create-project-cmd": "App\\Console\\Installer::postInstall",
         "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump",
         "check": [
-            "@cs-check",
-            "@test"
+            "@test",
+            "@cs-check"
         ],
         "cs-check": "vendor/bin/phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "cs-fix": "vendor/bin/phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",


### PR DESCRIPTION
Tests should run (and possibly fail) first, sniffer is the less important thing to run IMO.