### PR TITLE
Remove Migrations Plugin from bootstrap.php

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -221,5 +221,3 @@ Type::build('datetime')
 if (Configure::read('debug')) {
     Plugin::load('DebugKit', ['bootstrap' => true]);
 }
-
-Plugin::load('Migrations');


### PR DESCRIPTION
Ref: https://github.com/cakephp/app/issues/452
Note: 2 PRs cause quick via GH.