### PR TITLE
Bootstrap: HTTP_X_FORWARDED_PROTO

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -140,7 +140,7 @@ if ($isCli) {
  */
 if (!Configure::read('App.fullBaseUrl')) {
     $s = null;
-    if (env('HTTPS')) {
+    if (env('HTTPS') || env('HTTP_X_FORWARDED_PROTO', 'http') == 'https') {
         $s = 's';
     }
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -140,7 +140,7 @@ if ($isCli) {
  */
 if (!Configure::read('App.fullBaseUrl')) {
     $s = null;
-    if (env('HTTPS') || env('HTTP_X_FORWARDED_PROTO', 'http') == 'https') {
+    if (env('HTTPS') || env('HTTP_X_FORWARDED_PROTO', 'http') === 'https') {
         $s = 's';
     }
 


### PR DESCRIPTION
When the bootstrapper sets the fullBaseUrl, it now takes into account any protocols forwarded in the HTTP_X_FORWARDED_PROTO environment variable. This is very useful when applications are behind load balancers which forward SSL while the application itself runs without SSL.