### PR TITLE
Improvement of .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,3 +34,6 @@
 *.mo binary
 *.pdf binary
 *.phar binary
+*.woff binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
Added binary attribute to webfonts to prevent problems with git handling webfonts as ASCII files. 
I know: No webfonts are used in the app-skeleton. But it is very likely that they are used in projects built on top of it :-)