### PR TITLE
Update .gitattributes for svg (which is xml)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 *.properties text
 *.txt text
 *.xml text
+*.svg text
 *.yml text
 .htaccess text
 


### PR DESCRIPTION
SVG is often used for non-photo-graphics and web fonts (fallback).