### PR TITLE
Add Type::build('timestamp')

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -192,6 +192,8 @@ Type::build('date')
     ->useImmutable();
 Type::build('datetime')
     ->useImmutable();
+Type::build('timestamp')
+    ->useImmutable();
 
 /*
  * Custom Inflector rules, can be set to correctly pluralize or singularize


### PR DESCRIPTION
added two lines to config/bootstrap.php, which will convert timestamp column data in Entity not into Cake\I18n\Time object but into Cake\I18n\FrozenTime object.
```
Type::build('timestamp')
    ->useImmutable();
```



## Description
When I was using PostgreSQL, the datetime column data in Entity Object was not converted to the object of `Cake\I18n\FrozenTime`, but was converted to the object of `Cake\I18n\Time`.

In the end, the behavior of application was not a bug, though I was really confused.
By inserting two lines I added, the timestamp will be automatically converted into `Cake\I18n\FrozenTime`.
I wish this change will help PostgreSQL or other DB users.

Even if you reject this PR, please consider a bit more to remain these two lines as commented out lines.

## Comment
At least, the document should show other DB users some cautions shown above, I think. So, nevertheless this PR is merged or rejected, I will create a PR to cakephp/docs.

I apologize you to skip the process below.
```
The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
```

Thank you.