### PR TITLE
Add coverage composer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /config/app.php
 /tmp/*
 /logs/*
+/webroot/coverage/*

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         ],
         "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
-        "test": "phpunit --colors=always"
+        "test": "phpunit --colors=always",
+        "coverage": "phpunit --log-junit webroot/coverage/unitreport.xml --coverage-html webroot/coverage --coverage-clover webroot/coverage/coverage.xml"
     }
 }


### PR DESCRIPTION
This is a super useful helper I use myself, and since we are now using composer scripts, here it goes:

    composer coverage

It will then write a full HTML coverage report to browse into /webroot/coverage/
Just browse afterwards to your

    http://example.local/coverage/index.html

and you can then click through the local coverage report generated.