### PR TITLE
Disable automatic serialization for JsonView and XmlView

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -60,10 +60,14 @@ class AppController extends Controller
      */
     public function beforeRender(Event $event)
     {
-        if (!array_key_exists('_serialize', $this->viewVars) &&
-            in_array($this->response->type(), ['application/json', 'application/xml'])
-        ) {
-            $this->set('_serialize', true);
-        }
+        /*
+         * Uncomment the following to allow automatic viewVars serialization
+         * when using JsonView or XmlView.
+         */
+        //if (!array_key_exists('_serialize', $this->viewVars) &&
+        //    in_array($this->response->type(), ['application/json', 'application/xml'])
+        //) {
+        //    $this->set('_serialize', true);
+        //}
     }
 }


### PR DESCRIPTION
Dumping the content of viewVars by default can pose a security
risk as it may contain sensitive information.
