### PR TITLE
Removed death-star constraint from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cakephp/cakephp": "3.4.*",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
-        "cakephp/plugin-installer": "~0.0.15"
+        "cakephp/plugin-installer": "~1.0"
     },
     "require-dev": {
         "psy/psysh": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cakephp/cakephp": "3.4.*",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
-        "cakephp/plugin-installer": "*"
+        "cakephp/plugin-installer": "~0.0.15"
     },
     "require-dev": {
         "psy/psysh": "@stable",


### PR DESCRIPTION
As explained in https://thephp.cc/news/2017/02/death-star-version-constraint a '*' constraint is not really a constraint and upgrading to new major versions should be a conscious decision, therefore it should be replaced with a real constraint.