### PR TITLE
Suggest IdeHelper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "suggest": {
         "markstory/asset_compress": "An asset compression plugin which provides file concatenation and a flexible filter system for preprocessing and minification.",
-        "dereuromark/cakephp-ide-helper": "After baking your code, this keeps your annotations in sync with the code evolving from there on for maximum IDE compatibility.",
+        "dereuromark/cakephp-ide-helper": "After baking your code, this keeps your annotations in sync with the code evolving from there on for maximum IDE and PHPStan compatibility.",
         "phpunit/phpunit": "Allows automated tests to be run without system-wide install.",
         "cakephp/cakephp-codesniffer": "Allows to check the code against the coding standards used in CakePHP."
     },

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "suggest": {
         "markstory/asset_compress": "An asset compression plugin which provides file concatenation and a flexible filter system for preprocessing and minification.",
+        "dereuromark/cakephp-ide-helper": "After baking your code, this keeps your annotations in sync with the code evolving from there on for maximum IDE compatibility.",
         "phpunit/phpunit": "Allows automated tests to be run without system-wide install.",
         "cakephp/cakephp-codesniffer": "Allows to check the code against the coding standards used in CakePHP."
     },


### PR DESCRIPTION
The Bake plugin adds annotation only once, from there on the code gets out of sync with what the IDE needs to fully stay compatible, typehinting, autocomplete, error-detection, ...
The [IdeHelper](https://github.com/dereuromark/cakephp-ide-helper) is therefore just as important after the code is baked and re-baking is not an option anymore. Running it once a week for example can easily merge in the missing annotations or replace outdated ones.