### PR TITLE
feat: add support for loading .env files for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/*
 /config/app.php
+/config/.env
 /tmp/*
 /logs/*

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "cakephp/cakephp": "3.4.*",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
-        "cakephp/plugin-installer": "~1.0"
+        "cakephp/plugin-installer": "~1.0",
+        "josegonzalez/dotenv": "2.*"
     },
     "require-dev": {
         "psy/psysh": "@stable",

--- a/config/.env.default
+++ b/config/.env.default
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Place customizations in your config/.env file
+# and treat this file as distributable defaults
+
+export APP_NAME="__APP_NAME__"
+
+export DEBUG=true
+export SECURITY_SALT="__SALT__"
+
+export DATABASE_URL="mysql://my_app:secret@localhost/${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
+export DATABASE_TEST_URL="mysql://my_app:secret@localhost/test_${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
+
+export CACHE_DURATION="2+ minutes"
+export CACHE_DEFAULT_URL="file:///tmp/cache?prefix=${APP_NAME}_&duration=${CACHE_DURATION}"
+export CACHE_CAKECORE_URL="file:///tmp/cache/persistent?prefix=${APP_NAME}_cake_core_&duration=${CACHE_DURATION}&serialize=true"
+export CACHE_CAKEMODEL_URL="file:///tmp/cache/models?prefix=${APP_NAME}_cake_model_&duration=${CACHE_DURATION}&serialize=true"
+
+export LOG_DEBUG_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=debug"
+export LOG_SQL_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=sql&scopes[]=queriesLog"
+export LOG_ERROR_URL="file://logs?levels[]=warning&levels[]=error&levels[]=critical&levels[]=alert&levels[]=emergency&file=error"
+
+export EMAIL_DEFAULT_PROFILE="transport=default&from=you@localhost&to=${APP_NAME}@example.com"
+
+export EMAIL_TRANSPORT_DEFAULT_URL="mail://user:secret@localhost:25/?client=null&timeout=30&tls=null"

--- a/config/.env.default
+++ b/config/.env.default
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# To load, uncomment the line in config/bootstrap.php
+# that contains the following:
+#
+#    // Configure::load('env', 'default', true);
+#
 # Place customizations in your config/.env file
 # and treat this file as distributable defaults
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -75,6 +75,11 @@ use Cake\Utility\Security;
 try {
     Configure::config('default', new PhpConfig());
     Configure::load('app', 'default', false);
+    /*
+     * Uncomment the following line to enable loading .env files from the
+     * `config/` directory.
+     */
+    // Configure::load('env', 'default', true);
 } catch (\Exception $e) {
     exit($e->getMessage() . "\n");
 }

--- a/config/env.php
+++ b/config/env.php
@@ -1,0 +1,55 @@
+<?php
+use Cake\Utility\Hash;
+use josegonzalez\Dotenv\Loader;
+
+$config = [];
+if (!env('APP_NAME')) {
+    $dotenv = new Loader([
+        __DIR__ . DS . '.env',
+        __DIR__ . DS . '.env.default',
+    ]);
+    $dotenv->setFilters([
+        'josegonzalez\Dotenv\Filter\LowercaseKeyFilter',
+        'josegonzalez\Dotenv\Filter\UppercaseFirstKeyFilter',
+        'josegonzalez\Dotenv\Filter\UnderscoreArrayFilter',
+        function ($data) {
+            $keys = [
+                'App.fullbaseurl' => 'App.fullBaseUrl',
+                'Debug' => 'debug',
+                'Email.transport' => 'EmailTransport',
+                'Database.debug.kit' => 'Datasources.debug_kit',
+                'Database.test' => 'Datasources.test',
+                'Database' => 'Datasources.default',
+                'Cache.duration' => null,
+                'Cache.cakemodel' => 'Cache._cake_model_',
+                'Cache.cakecore' => 'Cache._cake_core_',
+            ];
+            foreach ($keys as $key => $newKey) {
+                if ($newKey === null) {
+                    $data = Hash::remove($data, $key);
+                    continue;
+                }
+                $value = Hash::get($data, $key);
+                $data = Hash::remove($data, $key);
+                if ($value !== null) {
+                    $data = Hash::insert($data, $newKey, $value);
+                }
+            }
+
+            foreach ($data['Email'] as $key => $config) {
+                if (isset($config['profile'])) {
+                    parse_str($config['profile'], $output);
+                    $data['Email'][$key] = array_merge($output, $data['Email'][$key]);
+                    unset($data['Email'][$key]['profile'], $output);
+                }
+            }
+
+            return $data;
+        }
+    ]);
+    $dotenv->parse();
+    $dotenv->filter();
+    $config = $dotenv->toArray();
+}
+
+return $config;

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -39,6 +39,7 @@ class Installer
         $rootDir = dirname(dirname(__DIR__));
 
         static::createAppConfig($rootDir, $io);
+        static::createEnvFile($rootDir, $io);
         static::createWritableDirectories($rootDir, $io);
 
         // ask if the permissions should be changed
@@ -84,6 +85,27 @@ class Installer
         if (!file_exists($appConfig)) {
             copy($defaultConfig, $appConfig);
             $io->write('Created `config/app.php` file');
+        }
+    }
+
+    /**
+     * Create the config/.env file if it does not exist.
+     * Also sets the APP_NAME value to the proper variable
+     *
+     * @param string $dir The application's root directory.
+     * @param \Composer\IO\IOInterface $io IO interface to write to console.
+     * @return void
+     */
+    public static function createEnvFile($dir, $io)
+    {
+        $appName = basename($dir);
+        static::setAppNameInFile($dir, $io, $appName, '.env.default');
+
+        $envFile = $dir . '/config/.env';
+        $defaultEnvFile = $dir . '/config/.env.default';
+        if (!file_exists($envFile)) {
+            copy($defaultEnvFile, $envFile);
+            $io->write('Created `config/.env` file');
         }
     }
 
@@ -172,10 +194,25 @@ class Installer
      */
     public static function setSecuritySalt($dir, $io)
     {
-        $config = $dir . '/config/app.php';
-        $content = file_get_contents($config);
-
         $newKey = hash('sha256', Security::randomBytes(64));
+
+        static::setSecuritySaltInFile($dir, $io, $newKey, 'app.php');
+        static::setSecuritySaltInFile($dir, $io, $newKey, '.env');
+    }
+
+    /**
+     * Set the security.salt value in a given file
+     *
+     * @param string $dir The application's root directory.
+     * @param \Composer\IO\IOInterface $io IO interface to write to console.
+     * @param string $newKey key to set in the file
+     * @param string $file A path to a file relative to the application's root
+     * @return void
+     */
+    public static function setSecuritySaltInFile($dir, $io, $newKey, $file)
+    {
+        $config = $dir . '/config/' . $file;
+        $content = file_get_contents($config);
         $content = str_replace('__SALT__', $newKey, $content, $count);
 
         if ($count == 0) {
@@ -186,10 +223,40 @@ class Installer
 
         $result = file_put_contents($config, $content);
         if ($result) {
-            $io->write('Updated Security.salt value in config/app.php');
+            $io->write('Updated Security.salt value in config/' . $file);
 
             return;
         }
         $io->write('Unable to update Security.salt value.');
+    }
+
+    /**
+     * Set the APP_NAME value in a given file
+     *
+     * @param string $dir The application's root directory.
+     * @param \Composer\IO\IOInterface $io IO interface to write to console.
+     * @param string $appName app name to set in the file
+     * @param string $file A path to a file relative to the application's root
+     * @return void
+     */
+    public static function setAppNameInFile($dir, $io, $appName, $file)
+    {
+        $config = $dir . '/config/' . $file;
+        $content = file_get_contents($config);
+        $content = str_replace('__APP_NAME__', $appName, $content, $count);
+
+        if ($count == 0) {
+            $io->write('No __APP_NAME__ placeholder to replace.');
+
+            return;
+        }
+
+        $result = file_put_contents($config, $content);
+        if ($result) {
+            $io->write('Updated __APP_NAME__ value in config/' . $file);
+
+            return;
+        }
+        $io->write('Unable to update __APP_NAME__ value.');
     }
 }


### PR DESCRIPTION
To use, uncomment the following line in your `config/bootstrap.php` file:

    // Configure::load('env', 'default', true);

This will load - in order - the `config/.env` and `config/.env.default` files. If this line is uncommented *but*
there is an environment variable set called `APP_NAME`, then no `.env` files will be loaded/parsed.

A missing `config/.env` file will be ignored when this integration is enabled, though removal of the
`config/.env.default` file will result in errors as it is the last file to be loaded. The first file that is parsed
and loaded will result in those environment variables being set as configuration, and no further
`.env` files will be parsed.

Any customizations *should* be performed in the `config/.env` file, with sane defaults present in the
`config/.env.default`. It is recommended that the corresponding environment variables are loaded through
`config/app.php` and `config/app.php.default` as well, so that production configurations with `APP_NAME`
present will be able to use environment variables as well.

This integration *will not* modify any superglobals, but will instead result in the .env contents
being merged into the configuration provided by `config/app.php`.

Closes cakephp/cakephp#10420