### PR TITLE
Codesniffer and CS fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require-dev": {
         "psy/psysh": "@stable",
         "cakephp/debug_kit": "~3.2",
-        "cakephp/bake": "~1.1"
+        "cakephp/bake": "~1.1",
+        "cakephp/cakephp-codesniffer": "^2"
     },
     "suggest": {
         "markstory/asset_compress": "An asset compression plugin which provides file concatenation and a flexible filter system for preprocessing and minification.",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psy/psysh": "@stable",
         "cakephp/debug_kit": "~3.2",
         "cakephp/bake": "~1.1",
-        "cakephp/cakephp-codesniffer": "^2"
+        "cakephp/cakephp-codesniffer": "^3.0"
     },
     "suggest": {
         "markstory/asset_compress": "An asset compression plugin which provides file concatenation and a flexible filter system for preprocessing and minification.",

--- a/src/Template/Email/html/default.ctp
+++ b/src/Template/Email/html/default.ctp
@@ -12,11 +12,9 @@
  * @since         0.10.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-?>
-<?php
+
 $content = explode("\n", $content);
 
-foreach ($content as $line):
+foreach ($content as $line) :
     echo '<p> ' . $line . "</p>\n";
 endforeach;
-?>

--- a/src/Template/Email/text/default.ctp
+++ b/src/Template/Email/text/default.ctp
@@ -12,5 +12,5 @@
  * @since         0.10.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-?>
-<?= $content ?>
+
+echo $content;

--- a/src/Template/Error/error400.ctp
+++ b/src/Template/Error/error400.ctp
@@ -4,7 +4,7 @@ use Cake\Error\Debugger;
 
 $this->layout = 'error';
 
-if (Configure::read('debug')):
+if (Configure::read('debug')) :
     $this->layout = 'dev_error';
 
     $this->assign('title', $message);
@@ -24,11 +24,11 @@ if (Configure::read('debug')):
 <?php endif; ?>
 <?= $this->element('auto_table_warning') ?>
 <?php
-    if (extension_loaded('xdebug')):
-        xdebug_print_function_stack();
-    endif;
+if (extension_loaded('xdebug')) :
+    xdebug_print_function_stack();
+endif;
 
-    $this->end();
+$this->end();
 endif;
 ?>
 <h2><?= h($message) ?></h2>

--- a/src/Template/Error/error500.ctp
+++ b/src/Template/Error/error500.ctp
@@ -4,7 +4,7 @@ use Cake\Error\Debugger;
 
 $this->layout = 'error';
 
-if (Configure::read('debug')):
+if (Configure::read('debug')) :
     $this->layout = 'dev_error';
 
     $this->assign('title', $message);
@@ -29,7 +29,7 @@ if (Configure::read('debug')):
 <?php
     echo $this->element('auto_table_warning');
 
-    if (extension_loaded('xdebug')):
+    if (extension_loaded('xdebug')) :
         xdebug_print_function_stack();
     endif;
 

--- a/src/Template/Layout/Email/text/default.ctp
+++ b/src/Template/Layout/Email/text/default.ctp
@@ -12,5 +12,5 @@
  * @since         0.10.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-?>
-<?= $this->fetch('content') ?>
+
+ $this->fetch('content');

--- a/src/Template/Layout/ajax.ctp
+++ b/src/Template/Layout/ajax.ctp
@@ -12,5 +12,5 @@
  * @since         0.10.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-?>
-<?= $this->fetch('content') ?>
+
+$this->fetch('content');

--- a/src/Template/Layout/rss/default.ctp
+++ b/src/Template/Layout/rss/default.ctp
@@ -1,14 +1,11 @@
 <?php
-if (!isset($channel)):
+if (!isset($channel)) :
     $channel = [];
 endif;
-if (!isset($channel['title'])):
+if (!isset($channel['title'])) :
     $channel['title'] = $this->fetch('title');
 endif;
 
 echo $this->Rss->document(
-    $this->Rss->channel(
-        [], $channel, $this->fetch('content')
-    )
+    $this->Rss->channel([], $channel, $this->fetch('content'))
 );
-?>

--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -21,7 +21,7 @@ use Cake\Network\Exception\NotFoundException;
 
 $this->layout = false;
 
-if (!Configure::read('debug')):
+if (!Configure::read('debug')) :
     throw new NotFoundException('Please replace src/Template/Pages/home.ctp with your own version.');
 endif;
 
@@ -73,29 +73,29 @@ $cakeDescription = 'CakePHP: the rapid development PHP framework';
     <div class="columns large-6">
         <h4>Environment</h4>
         <ul>
-        <?php if (version_compare(PHP_VERSION, '5.6.0', '>=')): ?>
+        <?php if (version_compare(PHP_VERSION, '5.6.0', '>=')) : ?>
             <li class="bullet success">Your version of PHP is 5.6.0 or higher (detected <?= PHP_VERSION ?>).</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">Your version of PHP is too low. You need PHP 5.6.0 or higher to use CakePHP (detected <?= PHP_VERSION ?>).</li>
         <?php endif; ?>
 
-        <?php if (extension_loaded('mbstring')): ?>
+        <?php if (extension_loaded('mbstring')) : ?>
             <li class="bullet success">Your version of PHP has the mbstring extension loaded.</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">Your version of PHP does NOT have the mbstring extension loaded.</li>;
         <?php endif; ?>
 
-        <?php if (extension_loaded('openssl')): ?>
+        <?php if (extension_loaded('openssl')) : ?>
             <li class="bullet success">Your version of PHP has the openssl extension loaded.</li>
-        <?php elseif (extension_loaded('mcrypt')): ?>
+        <?php elseif (extension_loaded('mcrypt')) : ?>
             <li class="bullet success">Your version of PHP has the mcrypt extension loaded.</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">Your version of PHP does NOT have the openssl or mcrypt extension loaded.</li>
         <?php endif; ?>
 
-        <?php if (extension_loaded('intl')): ?>
+        <?php if (extension_loaded('intl')) : ?>
             <li class="bullet success">Your version of PHP has the intl extension loaded.</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">Your version of PHP does NOT have the intl extension loaded.</li>
         <?php endif; ?>
         </ul>
@@ -103,22 +103,22 @@ $cakeDescription = 'CakePHP: the rapid development PHP framework';
     <div class="columns large-6">
         <h4>Filesystem</h4>
         <ul>
-        <?php if (is_writable(TMP)): ?>
+        <?php if (is_writable(TMP)) : ?>
             <li class="bullet success">Your tmp directory is writable.</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">Your tmp directory is NOT writable.</li>
         <?php endif; ?>
 
-        <?php if (is_writable(LOGS)): ?>
+        <?php if (is_writable(LOGS)) : ?>
             <li class="bullet success">Your logs directory is writable.</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">Your logs directory is NOT writable.</li>
         <?php endif; ?>
 
         <?php $settings = Cache::getConfig('_cake_core_'); ?>
-        <?php if (!empty($settings)): ?>
+        <?php if (!empty($settings)) : ?>
             <li class="bullet success">The <em><?= $settings['className'] ?>Engine</em> is being used for core caching. To change the config edit config/app.php</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">Your cache is NOT working. Please check the settings in config/app.php</li>
         <?php endif; ?>
         </ul>
@@ -136,18 +136,18 @@ $cakeDescription = 'CakePHP: the rapid development PHP framework';
         } catch (Exception $connectionError) {
             $connected = false;
             $errorMsg = $connectionError->getMessage();
-            if (method_exists($connectionError, 'getAttributes')):
+            if (method_exists($connectionError, 'getAttributes')) :
                 $attributes = $connectionError->getAttributes();
-                if (isset($errorMsg['message'])):
+                if (isset($errorMsg['message'])) :
                     $errorMsg .= '<br />' . $attributes['message'];
                 endif;
             endif;
         }
         ?>
         <ul>
-        <?php if ($connected): ?>
+        <?php if ($connected) : ?>
             <li class="bullet success">CakePHP is able to connect to the database.</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">CakePHP is NOT able to connect to the database.<br /><?= $errorMsg ?></li>
         <?php endif; ?>
         </ul>
@@ -155,9 +155,9 @@ $cakeDescription = 'CakePHP: the rapid development PHP framework';
     <div class="columns large-6">
         <h4>DebugKit</h4>
         <ul>
-        <?php if (Plugin::loaded('DebugKit')): ?>
+        <?php if (Plugin::loaded('DebugKit')) : ?>
             <li class="bullet success">DebugKit is loaded.</li>
-        <?php else: ?>
+        <?php else : ?>
             <li class="bullet problem">DebugKit is NOT loaded. You need to either install pdo_sqlite, or define the "debug_kit" connection name.</li>
         <?php endif; ?>
         </ul>


### PR DESCRIPTION
Notices that we do not make use of our codesniffer for the app template.
Added the CodeSniffer in version 2.x first, as it returned more violations.
Seems our CakePHP 3.x codesniffer does not cover everything that version 2 did.
For example, version 2.x returned violations from a ``InlineIfDeclarationSniff`` rule (space before colon), where as version 3.x did not.