### PR TITLE
Improve "error" message on home page

### DIFF
--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -22,7 +22,9 @@ use Cake\Network\Exception\NotFoundException;
 $this->layout = false;
 
 if (!Configure::read('debug')) :
-    throw new NotFoundException('Please replace src/Template/Pages/home.ctp with your own version.');
+    throw new NotFoundException(
+        'Please replace src/Template/Pages/home.ctp with your own version or re-enable debug mode.'
+    );
 endif;
 
 $cakeDescription = 'CakePHP: the rapid development PHP framework';


### PR DESCRIPTION
Disabled debug mode locally in my app yesterday and ran into this error message which was not very useful. Luckily, I remembered I disabled the debug mode.

Refers to https://github.com/cakephp/cakephp/issues/10752

