### PR TITLE
Add dotenv with fewer transformations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/*
 /config/app.php
+/config/.env
 /tmp/*
 /logs/*

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "cakephp/cakephp": "dev-3.next as 3.5.0",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
-        "cakephp/plugin-installer": "~1.0"
+        "cakephp/plugin-installer": "~1.0",
+        "josegonzalez/dotenv": "2.*"
     },
     "require-dev": {
         "psy/psysh": "@stable",

--- a/config/.env.default
+++ b/config/.env.default
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Used as a default for seeding
+# config/.env which enables you to use environment variables
+# to configure the aspects of your application that vary by
+# environment. In development .env files are parsed by PHP
+# and set into the environment. This provides a simpler
+# development workflow over standard environment variables.
+export APP_NAME="__APP_NAME__"
+export DEBUG="true"
+export APP_ENCODING="UTF-8"
+export APP_DEFAULT_LOCALE="en_US"
+export SECURITY_SALT="__SALT__"
+
+export CACHE_DURATION="+2 minutes"
+export CACHE_DEFAULT_URL="file://tmp/cache/?prefix=${APP_NAME}_default&duration=${CACHE_DURATION}"
+export CACHE_CAKECORE_URL="file://tmp/cache/persistent?prefix=${APP_NAME}_cake_core&serialize=true&duration=${CACHE_DURATION}"
+export CACHE_CAKEMODEL_URL="file://tmp/cache/models?prefix=${APP_NAME}_cake_model&serialize=true&duration=${CACHE_DURATION}"
+
+export EMAIL_TRANSPORT_DEFAULT_URL=""
+
+export DATABASE_URL="mysql://my_app:secret@localhost/${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
+export DATABASE_TEST_URL="mysql://my_app:secret@localhost/test_${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
+
+export LOG_DEBUG_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=debug"
+export LOG_ERROR_URL="file://logs?levels[]=warning&levels[]=error&levels[]=critical&levels[]=alert&levels[]=emergency&file=error"

--- a/config/.env.default
+++ b/config/.env.default
@@ -21,5 +21,6 @@ export EMAIL_TRANSPORT_DEFAULT_URL=""
 export DATABASE_URL="mysql://my_app:secret@localhost/${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
 export DATABASE_TEST_URL="mysql://my_app:secret@localhost/test_${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
 
-export LOG_DEBUG_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=debug"
-export LOG_ERROR_URL="file://logs?levels[]=warning&levels[]=error&levels[]=critical&levels[]=alert&levels[]=emergency&file=error"
+# Uncomment these to define logging configuration via environment variables.
+#export LOG_DEBUG_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=debug"
+#export LOG_ERROR_URL="file://logs?levels[]=warning&levels[]=error&levels[]=critical&levels[]=alert&levels[]=emergency&file=error"

--- a/config/.env.default
+++ b/config/.env.default
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# Used as a default for seeding
-# config/.env which enables you to use environment variables
-# to configure the aspects of your application that vary by
-# environment. In development .env files are parsed by PHP
+# Used as a default to seed config/.env which
+# enables you to use environment variables to configure
+# the aspects of your application that vary by
+# environment.
+#
+# To use this file, first copy it into `config/.env`.
+#
+# In development .env files are parsed by PHP
 # and set into the environment. This provides a simpler
 # development workflow over standard environment variables.
 export APP_NAME="__APP_NAME__"

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -64,6 +64,20 @@ use Cake\Mailer\Email;
 use Cake\Utility\Inflector;
 use Cake\Utility\Security;
 
+/**
+ * Read .env file if APP_NAME is not set.
+ *
+ * You can remove this block if you do not want to use environment
+ * variables for configuration when deploying.
+ */
+if (!env('APP_NAME') && file_exists(CONFIG . '.env')) {
+    $dotenv = new \josegonzalez\Dotenv\Loader([CONFIG . '.env']);
+    $dotenv->parse()
+        ->putenv()
+        ->toEnv()
+        ->toServer();
+}
+
 /*
  * Read configuration file and inject configuration into various
  * CakePHP classes.

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -39,7 +39,6 @@ class Installer
         $rootDir = dirname(dirname(__DIR__));
 
         static::createAppConfig($rootDir, $io);
-        static::createEnvFile($rootDir, $io);
         static::createWritableDirectories($rootDir, $io);
 
         // ask if the permissions should be changed
@@ -85,27 +84,6 @@ class Installer
         if (!file_exists($appConfig)) {
             copy($defaultConfig, $appConfig);
             $io->write('Created `config/app.php` file');
-        }
-    }
-
-    /**
-     * Create the config/.env file if it does not exist.
-     * Also sets the APP_NAME value to the proper variable
-     *
-     * @param string $dir The application's root directory.
-     * @param \Composer\IO\IOInterface $io IO interface to write to console.
-     * @return void
-     */
-    public static function createEnvFile($dir, $io)
-    {
-        $appName = basename($dir);
-        static::setAppNameInFile($dir, $io, $appName, '.env.default');
-
-        $envFile = $dir . '/config/.env';
-        $defaultEnvFile = $dir . '/config/.env.default';
-        if (!file_exists($envFile)) {
-            copy($defaultEnvFile, $envFile);
-            $io->write('Created `config/.env` file');
         }
     }
 
@@ -196,7 +174,6 @@ class Installer
     {
         $newKey = hash('sha256', Security::randomBytes(64));
         static::setSecuritySaltInFile($dir, $io, $newKey, 'app.php');
-        static::setSecuritySaltInFile($dir, $io, $newKey, '.env');
     }
 
     /**


### PR DESCRIPTION
I've borrowed very liberally from the changes in #506 for this. In talking with @lorenzo he wasn't entirely happy with the number of transformations being done to the environment variables. This approach does no additional transformations and should enable the `.env` file and native environments variables to work exactly the same.