### PR TITLE
Keep env vars commented.

### DIFF
--- a/config/.env.default
+++ b/config/.env.default
@@ -15,15 +15,15 @@ export APP_ENCODING="UTF-8"
 export APP_DEFAULT_LOCALE="en_US"
 export SECURITY_SALT="__SALT__"
 
-export CACHE_DURATION="+2 minutes"
-export CACHE_DEFAULT_URL="file://tmp/cache/?prefix=${APP_NAME}_default&duration=${CACHE_DURATION}"
-export CACHE_CAKECORE_URL="file://tmp/cache/persistent?prefix=${APP_NAME}_cake_core&serialize=true&duration=${CACHE_DURATION}"
-export CACHE_CAKEMODEL_URL="file://tmp/cache/models?prefix=${APP_NAME}_cake_model&serialize=true&duration=${CACHE_DURATION}"
+#export CACHE_DURATION="+2 minutes"
+#export CACHE_DEFAULT_URL="file://tmp/cache/?prefix=${APP_NAME}_default&duration=${CACHE_DURATION}"
+#export CACHE_CAKECORE_URL="file://tmp/cache/persistent?prefix=${APP_NAME}_cake_core&serialize=true&duration=${CACHE_DURATION}"
+#export CACHE_CAKEMODEL_URL="file://tmp/cache/models?prefix=${APP_NAME}_cake_model&serialize=true&duration=${CACHE_DURATION}"
 
-export EMAIL_TRANSPORT_DEFAULT_URL=""
+#export EMAIL_TRANSPORT_DEFAULT_URL=""
 
-export DATABASE_URL="mysql://my_app:secret@localhost/${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
-export DATABASE_TEST_URL="mysql://my_app:secret@localhost/test_${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
+#export DATABASE_URL="mysql://my_app:secret@localhost/${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
+#export DATABASE_TEST_URL="mysql://my_app:secret@localhost/test_${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
 
 # Uncomment these to define logging configuration via environment variables.
 #export LOG_DEBUG_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=debug"


### PR DESCRIPTION
Making users uncomment them ensures they will hopefully notice the default values set and update as required.
During a live coding session an individual copied `.env.default` to `.env` without noticing that `/tmp/cache` was now being used as cache folder and kept trying to modifying perms of `tmp/cache` inside the app folder.