### PR TITLE
Making usage of `.env` file opt-in instead of opt-out.

### DIFF
--- a/config/.env.default
+++ b/config/.env.default
@@ -4,7 +4,8 @@
 # the aspects of your application that vary by
 # environment.
 #
-# To use this file, first copy it into `config/.env`.
+# To use this file, first copy it into `config/.env`. Also ensure the related
+# code block for loading this file is uncommented in `config/boostrap.php`
 #
 # In development .env files are parsed by PHP
 # and set into the environment. This provides a simpler
@@ -15,15 +16,18 @@ export APP_ENCODING="UTF-8"
 export APP_DEFAULT_LOCALE="en_US"
 export SECURITY_SALT="__SALT__"
 
-export CACHE_DURATION="+2 minutes"
-export CACHE_DEFAULT_URL="file://tmp/cache/?prefix=${APP_NAME}_default&duration=${CACHE_DURATION}"
-export CACHE_CAKECORE_URL="file://tmp/cache/persistent?prefix=${APP_NAME}_cake_core&serialize=true&duration=${CACHE_DURATION}"
-export CACHE_CAKEMODEL_URL="file://tmp/cache/models?prefix=${APP_NAME}_cake_model&serialize=true&duration=${CACHE_DURATION}"
+# Uncomment these to define cache configuration via environment variables.
+#export CACHE_DURATION="+2 minutes"
+#export CACHE_DEFAULT_URL="file://tmp/cache/?prefix=${APP_NAME}_default&duration=${CACHE_DURATION}"
+#export CACHE_CAKECORE_URL="file://tmp/cache/persistent?prefix=${APP_NAME}_cake_core&serialize=true&duration=${CACHE_DURATION}"
+#export CACHE_CAKEMODEL_URL="file://tmp/cache/models?prefix=${APP_NAME}_cake_model&serialize=true&duration=${CACHE_DURATION}"
 
-export EMAIL_TRANSPORT_DEFAULT_URL=""
+# Uncomment these to define email transport configuration via environment variables.
+#export EMAIL_TRANSPORT_DEFAULT_URL=""
 
-export DATABASE_URL="mysql://my_app:secret@localhost/${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
-export DATABASE_TEST_URL="mysql://my_app:secret@localhost/test_${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
+# Uncomment these to define database configuration via environment variables.
+#export DATABASE_URL="mysql://my_app:secret@localhost/${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
+#export DATABASE_TEST_URL="mysql://my_app:secret@localhost/test_${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
 
 # Uncomment these to define logging configuration via environment variables.
 #export LOG_DEBUG_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=debug"

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -45,18 +45,17 @@ use Cake\Utility\Inflector;
 use Cake\Utility\Security;
 
 /**
- * Read .env file if APP_NAME is not set.
- *
- * You can remove this block if you do not want to use environment
- * variables for configuration when deploying.
+ * Uncomment block of code below if you want to `.env` file during development.
+ * You should copy `config/.env.default to `config/.env` and set/modify the
+ * variables as required.
  */
-if (!env('APP_NAME') && file_exists(CONFIG . '.env')) {
-    $dotenv = new \josegonzalez\Dotenv\Loader([CONFIG . '.env']);
-    $dotenv->parse()
-        ->putenv()
-        ->toEnv()
-        ->toServer();
-}
+// if (!env('APP_NAME') && file_exists(CONFIG . '.env')) {
+//     $dotenv = new \josegonzalez\Dotenv\Loader([CONFIG . '.env']);
+//     $dotenv->parse()
+//         ->putenv()
+//         ->toEnv()
+//         ->toServer();
+// }
 
 /*
  * Read configuration file and inject configuration into various


### PR DESCRIPTION
Also comment out important vars in `.env.default` so that after copying it to `.env`
users have to explicitly uncomment and set proper values.