### PR TITLE
Use UTF-8 Full Unicode / 4 Byte by default

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -289,7 +289,7 @@ return [
             'cacheMetadata' => true,
             'quoteIdentifiers' => false,
             'log' => false,
-            //'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
+            // 'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
             'url' => env('DATABASE_TEST_URL', null),
         ],
     ],

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -232,7 +232,8 @@ return [
             'username' => 'my_app',
             'password' => 'secret',
             'database' => 'my_app',
-            'encoding' => 'utf8',
+            // Non MariaDB/MySQL equivalent is 'utf8'
+            'encoding' => 'utf8mb4',
             'timezone' => 'UTC',
             'flags' => [],
             'cacheMetadata' => true,
@@ -272,7 +273,8 @@ return [
             'username' => 'my_app',
             'password' => 'secret',
             'database' => 'test_myapp',
-            'encoding' => 'utf8',
+            // Non MariaDB/MySQL equivalent is 'utf8'
+            'encoding' => 'utf8mb4',
             'timezone' => 'UTC',
             'cacheMetadata' => true,
             'quoteIdentifiers' => false,

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -241,10 +241,6 @@ return [
             'database' => 'my_app',
             /*
              * You do not need to set this flag to use full utf-8 encoding (internal default since CakePHP 3.6).
-             * If you do these are the recommendations:
-             * 'encoding' => 'utf8mb4' // On MariaDB/MySQL for full UTF-8 encoding (4-byte)
-             * 'encoding' => 'utf8mb3' // On MariaDB/MySQL for limited UTF-8 encoding (3-byte, not recommended)
-             * 'encoding' => 'utf8' // On any other RDBMS for full 4-byte UTF-8 encoding (4-byte)
              */
             //'encoding' => 'utf8mb4',
             'timezone' => 'UTC',

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -212,10 +212,15 @@ return [
     /**
      * Connection information used by the ORM to connect
      * to your application's datastores.
-     * Do not use periods in database name - it may lead to error.
-     * See https://github.com/cakephp/cakephp/issues/6471 for details.
-     * Drivers include Mysql Postgres Sqlite Sqlserver
-     * See vendor\cakephp\cakephp\src\Database\Driver for complete list
+     *
+     * ### Notes
+     * - Drivers include Mysql Postgres Sqlite Sqlserver
+     *   See vendor\cakephp\cakephp\src\Database\Driver for complete list
+     * - Do not use periods in database name - it may lead to error.
+     *   See https://github.com/cakephp/cakephp/issues/6471 for details.
+     * - 'encoding' is recommended to be set to full UTF-8 4-Byte support.
+     *   E.g set it to 'utf8mb4' in MariaDB and MySQL and 'utf8' for any
+     *   other RDBMS.
      */
     'Datasources' => [
         'default' => [
@@ -232,8 +237,14 @@ return [
             'username' => 'my_app',
             'password' => 'secret',
             'database' => 'my_app',
-            // Non MariaDB/MySQL equivalent is 'utf8'
-            'encoding' => 'utf8mb4',
+            /**
+             * You do not need to set this flag to use full utf-8 encoding (internal default since CakePHP 3.6).
+             * If you do these are the recommendations:
+             * 'encoding' => 'utf8mb4' // On MariaDB/MySQL for full UTF-8 encoding (4-byte)
+             * 'encoding' => 'utf8mb3' // On MariaDB/MySQL for limited UTF-8 encoding (3-byte, not recommended)
+             * 'encoding' => 'utf8' // On any other RDBMS for full 4-byte UTF-8 encoding (4-byte)
+             */
+            // 'encoding' => 'utf8mb4',
             'timezone' => 'UTC',
             'flags' => [],
             'cacheMetadata' => true,
@@ -273,8 +284,7 @@ return [
             'username' => 'my_app',
             'password' => 'secret',
             'database' => 'test_myapp',
-            // Non MariaDB/MySQL equivalent is 'utf8'
-            'encoding' => 'utf8mb4',
+            // 'encoding' => 'utf8mb4',
             'timezone' => 'UTC',
             'cacheMetadata' => true,
             'quoteIdentifiers' => false,

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -228,7 +228,7 @@ return [
             'driver' => 'Cake\Database\Driver\Mysql',
             'persistent' => false,
             'host' => 'localhost',
-            /**
+            /*
              * CakePHP will use the default DB port based on the driver selected
              * MySQL on MAMP uses port 8889, MAMP users will want to uncomment
              * the following line and set the port accordingly
@@ -237,7 +237,7 @@ return [
             'username' => 'my_app',
             'password' => 'secret',
             'database' => 'my_app',
-            /**
+            /*
              * You do not need to set this flag to use full utf-8 encoding (internal default since CakePHP 3.6).
              * If you do these are the recommendations:
              * 'encoding' => 'utf8mb4' // On MariaDB/MySQL for full UTF-8 encoding (4-byte)

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -44,7 +44,7 @@ return [
         'dir' => 'src',
         'webroot' => 'webroot',
         'wwwRoot' => WWW_ROOT,
-        // 'baseUrl' => env('SCRIPT_NAME'),
+        //'baseUrl' => env('SCRIPT_NAME'),
         'fullBaseUrl' => false,
         'imageBaseUrl' => 'img/',
         'cssBaseUrl' => 'css/',
@@ -76,7 +76,7 @@ return [
      * enable timestamping regardless of debug value.
      */
     'Asset' => [
-        // 'timestamp' => true,
+        //'timestamp' => true,
     ],
 
     /**
@@ -179,7 +179,9 @@ return [
     'EmailTransport' => [
         'default' => [
             'className' => 'Mail',
-            // The following keys are used in SMTP transports
+            /*
+             * The following keys are used in SMTP transports:
+             */
             'host' => 'localhost',
             'port' => 25,
             'timeout' => 30,
@@ -244,7 +246,7 @@ return [
              * 'encoding' => 'utf8mb3' // On MariaDB/MySQL for limited UTF-8 encoding (3-byte, not recommended)
              * 'encoding' => 'utf8' // On any other RDBMS for full 4-byte UTF-8 encoding (4-byte)
              */
-            // 'encoding' => 'utf8mb4',
+            //'encoding' => 'utf8mb4',
             'timezone' => 'UTC',
             'flags' => [],
             'cacheMetadata' => true,
@@ -284,12 +286,12 @@ return [
             'username' => 'my_app',
             'password' => 'secret',
             'database' => 'test_myapp',
-            // 'encoding' => 'utf8mb4',
+            //'encoding' => 'utf8mb4',
             'timezone' => 'UTC',
             'cacheMetadata' => true,
             'quoteIdentifiers' => false,
             'log' => false,
-            // 'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
+            //'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
             'url' => env('DATABASE_TEST_URL', null),
         ],
     ],


### PR DESCRIPTION
- [x] Enhancement

This change affects MySQL and MariaDB.

Otherwise utf8 support will mean your data gets truncated once a 4-byte utf8 symbol gets inserted such as `'😃'`

- Issue with more Info: https://github.com/cakephp/cakephp/issues/11324#issuecomment-336672560