### PR TITLE
Replaces deprecated `Response::type()` by `Response::getType()` (#555)

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -63,16 +63,16 @@ class AppController extends Controller
         // Note: These defaults are just to get started quickly with development
         // and should not be used in production. You should instead set "_serialize"
         // in each action as required.
-        if(!array_key_exists('_serialize', $this->viewVars)) {
+        if (!array_key_exists('_serialize', $this->viewVars)) {
             $mimeType = $this->RequestHandler->mapAlias(
-                            $this->RequestHandler->responseType());
-            if(!is_array($mimeType)) {
-                if(in_array($mimeType, ['application/json', 'application/xml'])) {
+                $this->RequestHandler->responseType()
+            );
+            if (!is_array($mimeType)) {
+                if (in_array($mimeType, ['application/json', 'application/xml'])) {
                     $this->set('_serialize', true);
                 }
-            }
-            else if(in_array('application/json', $mimeType) ||
-                    in_array('application/xml',  $mimeType)) {
+            } elseif (in_array('application/json', $mimeType) ||
+                      in_array('application/xml', $mimeType)) {
                 $this->set('_serialize', true);
             }
         }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -55,7 +55,7 @@ class AppController extends Controller
     /**
      * Before render callback.
      *
-     * @param  \Cake\Event\Event $event The beforeRender event.
+     * @param \Cake\Event\Event $event The beforeRender event.
      * @return \Cake\Http\Response|null|void
      */
     public function beforeRender(Event $event)
@@ -63,13 +63,10 @@ class AppController extends Controller
         // Note: These defaults are just to get started quickly with development
         // and should not be used in production.
         // You should instead set "_serialize" in each action as required.
-        if (!array_key_exists('_serialize', $this->viewVars)) {
-            $contentType = $this->response->getHeaderLine('Content-Type');
-            if (strpos($contentType, 'application/json') !== false ||
-                strpos($contentType, 'application/xml') !== false
-            ) {
-                $this->set('_serialize', true);
-            }
+        if (!array_key_exists('_serialize', $this->viewVars) &&
+            in_array($this->response->getType(), ['application/json', 'application/xml'])
+        ) {
+            $this->set('_serialize', true);
         }
     }
 }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -63,10 +63,18 @@ class AppController extends Controller
         // Note: These defaults are just to get started quickly with development
         // and should not be used in production. You should instead set "_serialize"
         // in each action as required.
-        if (!array_key_exists('_serialize', $this->viewVars) &&
-            in_array($this->response->type(), ['application/json', 'application/xml'])
-        ) {
-            $this->set('_serialize', true);
+        if(!array_key_exists('_serialize', $this->viewVars)) {
+            $mimeType = $this->RequestHandler->mapAlias(
+                            $this->RequestHandler->responseType());
+            if(!is_array($mimeType)) {
+                if(in_array($mimeType, ['application/json', 'application/xml'])) {
+                    $this->set('_serialize', true);
+                }
+            }
+            else if(in_array('application/json', $mimeType) ||
+                    in_array('application/xml',  $mimeType)) {
+                $this->set('_serialize', true);
+            }
         }
     }
 }

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -55,24 +55,19 @@ class AppController extends Controller
     /**
      * Before render callback.
      *
-     * @param \Cake\Event\Event $event The beforeRender event.
+     * @param  \Cake\Event\Event $event The beforeRender event.
      * @return \Cake\Http\Response|null|void
      */
     public function beforeRender(Event $event)
     {
         // Note: These defaults are just to get started quickly with development
-        // and should not be used in production. You should instead set "_serialize"
-        // in each action as required.
+        // and should not be used in production.
+        // You should instead set "_serialize" in each action as required.
         if (!array_key_exists('_serialize', $this->viewVars)) {
-            $mimeType = $this->RequestHandler->mapAlias(
-                $this->RequestHandler->responseType()
-            );
-            if (!is_array($mimeType)) {
-                if (in_array($mimeType, ['application/json', 'application/xml'])) {
-                    $this->set('_serialize', true);
-                }
-            } elseif (in_array('application/json', $mimeType) ||
-                      in_array('application/xml', $mimeType)) {
+            $contentType = $this->response->getHeaderLine('Content-Type');
+            if (strpos($contentType, 'application/json') !== false ||
+                strpos($contentType, 'application/xml') !== false
+            ) {
                 $this->set('_serialize', true);
             }
         }


### PR DESCRIPTION
I'm back !

So this is a workaround using `RequestHandler::mapAlias()` and `RequestHandler::responseType()`.
The only problem is the variable `$mimeType` may receive either a `string` or an `array`.
This is why the distinction of cases is done.

I've done some tests on my own, it _should_ work.
BUT, it'd be very interesting if some expert eyes could catch a glimpse of this 👀 

Last point : This is "bigger" than before, and if someone here has a better idea, let it known !

++ 👋

EDIT : 'would fix #555.
EDIT_2 : Sorry for the second commit, didn't know that Travis would complain about that...