### PR TITLE
Update htaccess to support LetsEncrypt

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,6 +6,7 @@
 
 <IfModule mod_rewrite.c>
     RewriteEngine on
+    RewriteRule    ^(\.well-known/.*)$ $1 [L]
     RewriteRule    ^$    webroot/    [L]
     RewriteRule    (.*) webroot/$1    [L]
 </IfModule>


### PR DESCRIPTION
Update rewrite rules in the base htaccess to directly expose the ".well-known" directory.  This adds support for LetsEncrypt utilities to successfully request certificates.

This was merged previously for Cake2, but not Cake3.  Issue #368.