### PR TITLE
Use recommended testsuite names

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
 
     <!-- Add any additional test suites you want to run here -->
     <testsuites>
-        <testsuite name="App Test Suite">
+        <testsuite name="app">
             <directory>./tests/TestCase</directory>
         </testsuite>
         <!-- Add plugin test suites here. -->


### PR DESCRIPTION
as per https://phpunit.de/manual/current/en/organizing-tests.html#organizing-tests.xml-configuration

also, `--testsuite foobar` doesnt require quoting, with spaces it does: `--testsuite "Foo Bar"`, besides the way more typing to get the desired testsuite to run standalone.