### PR TITLE
add route collection cache

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -118,6 +118,20 @@ return [
             'duration' => '+1 years',
             'url' => env('CACHE_CAKEMODEL_URL', null),
         ],
+
+        /**
+         * Configure the cache for routes. The cached routes collection is built the
+         * first time the routes are processed via `config/routes.php`.
+         * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
+         */
+        '_cake_routes_' => [
+            'className' => 'File',
+            'prefix' => 'myapp_cake_routes_',
+            'path' => CACHE,
+            'serialize' => true,
+            'duration' => '+1 years',
+            'url' => env('CACHE_CAKEROUTES_URL', null),
+        ],
     ],
 
     /**

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -122,7 +122,7 @@ return [
         /**
          * Configure the cache for routes. The cached routes collection is built the
          * first time the routes are processed via `config/routes.php`.
-         * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
+         * Duration will be set to '+2 seconds' in bootstrap.php when debug = true
          */
         '_cake_routes_' => [
             'className' => 'File',

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -107,6 +107,7 @@ try {
 if (Configure::read('debug')) {
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
     Configure::write('Cache._cake_core_.duration', '+2 minutes');
+    Configure::write('Cache._cake_routes_.duration', '+2 minutes');
 }
 
 /*

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -107,7 +107,8 @@ try {
 if (Configure::read('debug')) {
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
     Configure::write('Cache._cake_core_.duration', '+2 minutes');
-    Configure::write('Cache._cake_routes_.duration', '+2 minutes');
+    // disable router cache during development
+    Configure::write('Cache._cake_routes_.duration', '+0 minutes');
 }
 
 /*

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -108,7 +108,7 @@ if (Configure::read('debug')) {
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
     Configure::write('Cache._cake_core_.duration', '+2 minutes');
     // disable router cache during development
-    Configure::write('Cache._cake_routes_.duration', '+0 minutes');
+    Configure::write('Cache._cake_routes_.duration', '+2 seconds');
 }
 
 /*

--- a/config/routes.php
+++ b/config/routes.php
@@ -40,6 +40,9 @@ use Cake\Routing\Route\DashedRoute;
  * inconsistently cased URLs when used with `:plugin`, `:controller` and
  * `:action` markers.
  *
+ * Cache: Routes are cached to improve performance, check the RoutingMiddleware
+ * constructor in your `src/Application.php` file to change this behavior.
+ *
  */
 Router::defaultRouteClass(DashedRoute::class);
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -45,7 +45,10 @@ class Application extends BaseApplication
             ->add(AssetMiddleware::class)
 
             // Add routing middleware.
-            ->add(new RoutingMiddleware($this));
+            // Routes collection cache enabled by default, to disable route caching
+            // pass null as cacheConfig, example: `new RoutingMiddleware($this)`
+            // you might want to disable this cache in case your routing is extremely simple
+            ->add(new RoutingMiddleware($this, '_cake_routes_'));
 
         return $middlewareQueue;
     }


### PR DESCRIPTION
Add route collection caching.

I've been doing some more benchmarks locally (php builtin server) and there could be some cases for applications with a small (<5) number of routes where using cache by default will take 0.1-0.2 milliseconds more. This overhead is caused by the initial cache write, object serialization, network, etc.

I think this is not a strong reason to make it optional, as the benefits for non trivial cake applications are *huge*, but I'm open to suggestions. I've left a note in the Application.php class.

Thanks,