### PR TITLE
Add function to try to find a CLI version of PHP

### DIFF
--- a/bin/cake
+++ b/bin/cake
@@ -33,14 +33,36 @@ canonicalize() {
     echo "$NAME"
 }
 
+# Find a CLI version of PHP
+findCliPhp() {
+    for TESTEXEC in php php-cli /usr/local/bin/php
+    do
+        SAPI=`echo "<?= PHP_SAPI ?>" | $TESTEXEC 2>/dev/null`
+        if [ "$SAPI" = "cli" ]
+        then
+            echo $TESTEXEC
+            return
+        fi
+    done
+    echo "Failed to find a CLI version of PHP; falling back to system standard php executable" >&2
+    echo "php";
+}
+
 CONSOLE=$(dirname -- "$(canonicalize "$0")")
 APP=$(dirname "$CONSOLE")
 
+# If your CLI PHP is somewhere that this doesn't find, you can define a PHP environment
+# variable with the correct path in it.
+if [ -z "$PHP" ]
+then
+    PHP=$(findCliPhp)
+fi
+
 if [ $(basename $0) != 'cake' ]
 then
-    exec php "$CONSOLE"/cake.php $(basename $0) "$@"
+    exec $PHP "$CONSOLE"/cake.php $(basename $0) "$@"
 else
-    exec php "$CONSOLE"/cake.php "$@"
+    exec $PHP "$CONSOLE"/cake.php "$@"
 fi
 
 exit


### PR DESCRIPTION
Fixes #589.

I have included a way for people to set their required PHP via environment variable, if their setup doesn't match one of the pre-defined options. Is there any practical way that this could be exploited? If so, is there a way to sanitize that input before using it?