### PR TITLE
Simplify Installer::setFolderPermissions

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -135,14 +135,14 @@ class Installer
     public static function setFolderPermissions($dir, $io)
     {
         // Change the permissions on a path and output the results.
-        $changePerms = function ($path, $perms, $io) {
-            // Get permission bits from stat(2) result.
+        $changePerms = function ($path) use ($io) {
             $currentPerms = fileperms($path) & 0777;
-            if (($currentPerms & $perms) == $perms) {
+            $worldWritable = $currentPerms | 0007;
+            if ($worldWritable == $currentPerms) {
                 return;
             }
 
-            $res = chmod($path, $currentPerms | $perms);
+            $res = chmod($path, $worldWritable);
             if ($res) {
                 $io->write('Permissions set on ' . $path);
             } else {
@@ -150,7 +150,7 @@ class Installer
             }
         };
 
-        $walker = function ($dir, $perms, $io) use (&$walker, $changePerms) {
+        $walker = function ($dir) use (&$walker, $changePerms) {
             $files = array_diff(scandir($dir), ['.', '..']);
             foreach ($files as $file) {
                 $path = $dir . '/' . $file;
@@ -159,15 +159,14 @@ class Installer
                     continue;
                 }
 
-                $changePerms($path, $perms, $io);
-                $walker($path, $perms, $io);
+                $changePerms($path);
+                $walker($path);
             }
         };
 
-        $worldWritable = bindec('0000000111');
-        $walker($dir . '/tmp', $worldWritable, $io);
-        $changePerms($dir . '/tmp', $worldWritable, $io);
-        $changePerms($dir . '/logs', $worldWritable, $io);
+        $walker($dir . '/tmp');
+        $changePerms($dir . '/tmp');
+        $changePerms($dir . '/logs');
     }
 
     /**


### PR DESCRIPTION
* Pass less arguments between functions. Pass `$io` via `uses`, so PHPStorm tracks var type better.
* Use octal `0007` for permission mask instead of non-standard binary number. Simplify code of perms bitmasking, comparison.  