### PR TITLE
adds method bootstrap to App\Application

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -29,6 +29,15 @@ use Cake\Routing\Middleware\RoutingMiddleware;
 class Application extends BaseApplication
 {
     /**
+     * {@inheritDoc}
+     */
+    public function bootstrap()
+    {
+        // Call parent to load bootstrap from files.
+        parent::bootstrap();
+    }
+
+    /**
      * Setup the middleware queue your application will use.
      *
      * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.


### PR DESCRIPTION
Activating a plugin with `bin/cake plugin load myPlugin` throws "Your Application class does not have a bootstrap() method. Please add one."

Instead of an error message it would be nice to have the method already in place.