### PR TITLE
Allow phpstan.

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -83,8 +83,9 @@ class Installer
 
         static::setSecuritySalt($rootDir, $io);
 
-        if (class_exists('\Cake\Codeception\Console\Installer')) {
-            \Cake\Codeception\Console\Installer::customizeCodeceptionBinary($event);
+        $class = 'Cake\Codeception\Console\Installer';
+        if (class_exists($class)) {
+            $class::customizeCodeceptionBinary($event);
         }
     }
 


### PR DESCRIPTION
First step into https://github.com/cakephp/app/issues/572

With this fixed, a fresh app can now be green (even on level 7), given the following adjustments
composer dependency + scripts addon
```
"phpstan": "vendor/bin/phpstan analyse -l 7 -c tests/phpstan.neon src/"
```
and + autoload-dev psr4
```
"Cake\\PHPStan\\": "vendor/cakephp/cakephp/tests/PHPStan/"
```

I have the following neon file:
```
parameters:
    autoload_files:
        - tests/bootstrap.php
    earlyTerminatingMethodCalls:
        Cake\Shell\Shell:
            - abort

services:
    -
        class: Cake\PHPStan\AssociationTableMixinClassReflectionExtension
        tags:
            - phpstan.broker.methodsClassReflectionExtension
            - phpstan.broker.propertiesClassReflectionExtension
```


Then just run:
```
composer phpstan
```

Should all be fine.