### PR TITLE
Remove Plugin::routes()

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -77,9 +77,3 @@ Router::scope('/', function (RouteBuilder $routes) {
      */
     $routes->fallbacks(DashedRoute::class);
 });
-
-/**
- * Load all plugin routes. See the Plugin documentation on
- * how to customize the loading of plugin routes.
- */
-Plugin::routes();


### PR DESCRIPTION
When using the new plugin system this method is no longer necessary as
the plugin classes include routes during application startup.

Refs #593