### PR TITLE
issue 618 Log filename chage from dotenv

### DIFF
--- a/config/.env.default
+++ b/config/.env.default
@@ -31,5 +31,5 @@ export SECURITY_SALT="__SALT__"
 #export DATABASE_TEST_URL="mysql://my_app:secret@localhost/test_${APP_NAME}?encoding=utf8&timezone=UTC&cacheMetadata=true&quoteIdentifiers=false&persistent=false"
 
 # Uncomment these to define logging configuration via environment variables.
-#export LOG_DEBUG_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=debug"
-#export LOG_ERROR_URL="file://logs?levels[]=warning&levels[]=error&levels[]=critical&levels[]=alert&levels[]=emergency&file=error"
+#export LOG_DEBUG_URL="file://logs/?levels[]=notice&levels[]=info&levels[]=debug&file=debug"
+#export LOG_ERROR_URL="file://logs/?levels[]=warning&levels[]=error&levels[]=critical&levels[]=alert&levels[]=emergency&file=error"


### PR DESCRIPTION
https://github.com/cakephp/app/blob/2734ac7bdf9e69d5053faf14096c4e5c46260420/config/.env.default#L34

I would like to have `debug.log` and `error.log` under the logs. 
But `logsdebug.log`, `logserror.log`

```
#export LOG_DEBUG_URL="file://logs?levels[]=notice&levels[]=info&levels[]=debug&file=debug"
#export LOG_ERROR_URL="file://logs?levels[]=warning&levels[]=error&levels[]=critical&levels[]=alert&levels[]=emergency&file=error"
```
↓I want change.
```
#export LOG_DEBUG_URL="file://logs/?levels[]=notice&levels[]=info&levels[]=debug&file=debug"
#export LOG_ERROR_URL="file://logs/?levels[]=warning&levels[]=error&levels[]=critical&levels[]=alert&levels[]=emergency&file=error"
```