### PR TITLE
Remove deprecated tutorials from the app welcome page.

### DIFF
--- a/src/Template/Pages/home.ctp
+++ b/src/Template/Pages/home.ctp
@@ -179,9 +179,7 @@ $cakeDescription = 'CakePHP: the rapid development PHP framework';
         <h3>Getting Started</h3>
         <ul>
             <li class="bullet book"><a target="_blank" href="https://book.cakephp.org/3.0/en/">CakePHP 3.0 Docs</a></li>
-            <li class="bullet book"><a target="_blank" href="https://book.cakephp.org/3.0/en/tutorials-and-examples/bookmarks/intro.html">The 15 min Bookmarker Tutorial</a></li>
-            <li class="bullet book"><a target="_blank" href="https://book.cakephp.org/3.0/en/tutorials-and-examples/blog/blog.html">The 15 min Blog Tutorial</a></li>
-            <li class="bullet book"><a target="_blank" href="https://book.cakephp.org/3.0/en/tutorials-and-examples/cms/installation.html">The 15 min CMS Tutorial</a></li>
+            <li class="bullet book"><a target="_blank" href="https://book.cakephp.org/3.0/en/tutorials-and-examples/cms/installation.html">The 20 min CMS Tutorial</a></li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
Refs cakephp/docs#5822
