### PR TITLE
Add ability to configure Asset Cache time.

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -81,6 +81,7 @@ return [
      */
     'Asset' => [
         //'timestamp' => true,
+        // 'cacheTime' => '+1 year'
     ],
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -71,7 +71,9 @@ class Application extends BaseApplication
             ->add(ErrorHandlerMiddleware::class)
 
             // Handle plugin/theme assets like CakePHP normally does.
-            ->add(AssetMiddleware::class)
+            ->add(new AssetMiddleware([
+                'cacheTime' => Configure::read('Asset.cacheTime')
+            ]))
 
             // Add routing middleware.
             // Routes collection cache enabled by default, to disable route caching


### PR DESCRIPTION
**PLEASE NOTE:**

Relates to issue #624
[Issue #624](https://github.com/cakephp/app/issues/624)

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Adding the ability to change the asset cache time from `+1 day` to anything else. The recommended time should be `+1 year`. Google Chrome's Audit ability in the developer screen is saying that 1 day cache time is considered too short.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.