### PR TITLE
Add support for symlinked script call

### DIFF
--- a/bin/cake
+++ b/bin/cake
@@ -48,7 +48,14 @@ findCliPhp() {
     echo "php";
 }
 
-CONSOLE=$(dirname -- "$(canonicalize "$0")")
+# If current path is a symlink, resolve to real path
+realname="$0"
+if [ -L "$realname" ] 
+then
+	realname=$(readlink -f "$0")
+fi
+
+CONSOLE=$(dirname -- "$(canonicalize "$realname")")
 APP=$(dirname "$CONSOLE")
 
 # If your CLI PHP is somewhere that this doesn't find, you can define a PHP environment
@@ -58,9 +65,9 @@ then
     PHP=$(findCliPhp)
 fi
 
-if [ $(basename $0) != 'cake' ]
+if [ $(basename $realname) != 'cake' ]
 then
-    exec $PHP "$CONSOLE"/cake.php $(basename $0) "$@"
+    exec $PHP "$CONSOLE"/cake.php $(basename $realname) "$@"
 else
     exec $PHP "$CONSOLE"/cake.php "$@"
 fi


### PR DESCRIPTION
I added support for symlinked script call. 
The cake script (bin/cake) could not be called when symlinked to somewhere ($PATH in particular), because it tries to deduce the location of the php script (bin/cake.php) by the basename of the script. 
When using a symlink, the path of the symlink is passed via $0.

I added that the script detects whether "$0" is a symlink and follows the link to the real path. 

Concrete Use Case:
I want to run some Cake Shell commands regularly via cron. 
Therefore I symlinked bin/cake into $PATH, so I don't have to care about the real location.
The link is created during docker build.
With this improvement I can start the Cake Shell commands with a simple command in crontab.