### PR TITLE
Remove syntaxcheck attribute

### DIFF
--- a/config/paths.php
+++ b/config/paths.php
@@ -48,7 +48,7 @@ define('CONFIG', ROOT . DS . 'config' . DS);
 
 /**
  * File path to the webroot directory.
- * 
+ *
  * To derive your webroot from your webserver change this to:
  *
  * `define('WWW_ROOT', rtrim($_SERVER['DOCUMENT_ROOT'], DS) . DS);`

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="tests/bootstrap.php"
     >
     <php>


### PR DESCRIPTION
The attribute `syntaxCheck` has not had an effect in years. It was removed long ago.

refs :
https://stackoverflow.com/questions/44328114/phpunit-what-does-syntaxcheck-configuration-parameter-stands-for-exactly
https://phpunit.de/manual/5.7/en/appendixes.configuration.html