### PR TITLE
Register scoped middleware in Application::routes()

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -48,8 +48,8 @@ Router::defaultRouteClass(DashedRoute::class);
 
 Router::scope('/', function (RouteBuilder $routes) {
     /**
-     * Apply a middlewares to the current route scope.
-     * Requires middlewares to be registered via `Application::routes()` with `registerMiddleware()`
+     * Apply a middleware to the current route scope.
+     * Requires middleware to be registered via `Application::routes()` with `registerMiddleware()`
      */
     $routes->applyMiddleware('csrf');
 
@@ -85,7 +85,7 @@ Router::scope('/', function (RouteBuilder $routes) {
 });
 
 /**
- * If you need different set of middlewares or none at all, open new scope and define routes there
+ * If you need different set of middleware or none at all, open new scope and define routes there
  *
  * ```
  * Router::scope('/api', function (RouteBuilder $routes) {

--- a/config/routes.php
+++ b/config/routes.php
@@ -48,6 +48,12 @@ Router::defaultRouteClass(DashedRoute::class);
 
 Router::scope('/', function (RouteBuilder $routes) {
     /**
+     * Apply a middlewares to the current route scope.
+     * Requires middlewares to be registered via `Application::routes()` with `registerMiddleware()`
+     */
+    $routes->applyMiddleware('csrf');
+
+    /**
      * Here, we are connecting '/' (base path) to a controller called 'Pages',
      * its action called 'display', and we pass a param to select the view file
      * to use (in this case, src/Template/Pages/home.ctp)...
@@ -77,3 +83,14 @@ Router::scope('/', function (RouteBuilder $routes) {
      */
     $routes->fallbacks(DashedRoute::class);
 });
+
+/**
+ * If you need different set of middlewares or none at all, open new scope and define routes there
+ *
+ * ```
+ * Router::scope('/api', function (RouteBuilder $routes) {
+ *     // No $routes->applyMiddleware() here.
+ *     // Connect API actions here.
+ * });
+ * ```
+ */

--- a/src/Application.php
+++ b/src/Application.php
@@ -60,14 +60,14 @@ class Application extends BaseApplication
     /**
      * Define the routes for an application.
      *
-     * Use the provided RouteBuilder to define an application's routing, register scoped middlewares.
+     * Use the provided RouteBuilder to define an application's routing, register scoped middleware.
      *
      * @param \Cake\Routing\RouteBuilder $routes A route builder to add routes into.
      * @return void
      */
     public function routes($routes)
     {
-        // Register scoped middlewares for use in routes.php
+        // Register scoped middleware for use in routes.php
         $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware([
             'httpOnly' => true
         ]));

--- a/src/Application.php
+++ b/src/Application.php
@@ -58,6 +58,24 @@ class Application extends BaseApplication
     }
 
     /**
+     * Define the routes for an application.
+     *
+     * Use the provided RouteBuilder to define an application's routing, register scoped middlewares.
+     *
+     * @param \Cake\Routing\RouteBuilder $routes A route builder to add routes into.
+     * @return void
+     */
+    public function routes($routes)
+    {
+        // Register scoped middlewares for use in routes.php
+        $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware([
+            'httpOnly' => true
+        ]));
+
+        parent::routes($routes);
+    }
+
+    /**
      * Setup the middleware queue your application will use.
      *
      * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
@@ -79,12 +97,7 @@ class Application extends BaseApplication
             // Routes collection cache enabled by default, to disable route caching
             // pass null as cacheConfig, example: `new RoutingMiddleware($this)`
             // you might want to disable this cache in case your routing is extremely simple
-            ->add(new RoutingMiddleware($this, '_cake_routes_'))
-
-            // Add csrf middleware.
-            ->add(new CsrfProtectionMiddleware([
-                'httpOnly' => true
-            ]));
+            ->add(new RoutingMiddleware($this, '_cake_routes_'));
 
         return $middlewareQueue;
     }

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -17,7 +17,6 @@ namespace App\Test\TestCase;
 use App\Application;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\MiddlewareQueue;
-use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Routing\Middleware\AssetMiddleware;
 use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\TestSuite\IntegrationTestCase;
@@ -81,6 +80,5 @@ class ApplicationTest extends IntegrationTestCase
         $this->assertInstanceOf(ErrorHandlerMiddleware::class, $middleware->get(0));
         $this->assertInstanceOf(AssetMiddleware::class, $middleware->get(1));
         $this->assertInstanceOf(RoutingMiddleware::class, $middleware->get(2));
-        $this->assertInstanceOf(CsrfProtectionMiddleware::class, $middleware->get(3));
     }
 }


### PR DESCRIPTION
Recent change to add CSRF middleware to application middleware queue made many users confused due to CSRF token errors.

CSRF, encrypted cookies, authentication etc middlewares are better uses as scoped middlewares.

I suggest to use `Application::routes()` to register (and group) scoped middlewares. This way all middlewares are still configured in single file, some in `routes()`, some in `middleware()`, but separated.

Add `applyMiddleware()` and short example about separate scopes in `routes.php`.

This PR separates app-wide and scoped middlewares, it might be easier to communicate about differences and enabling/disabling scoped middlewares. In my opinion, `routes.php` has more visibility than `Application.php` between beginner CakePHP developers.