### PR TITLE
Sentence structure

### DIFF
--- a/src/Shell/ConsoleShell.php
+++ b/src/Shell/ConsoleShell.php
@@ -68,10 +68,10 @@ class ConsoleShell extends Shell
     {
         $parser = new ConsoleOptionParser('console');
         $parser->setDescription(
-            'This shell provides a REPL that you can use to interact ' .
-            'with your application in an interactive fashion. You can use ' .
-            'it to run adhoc queries with your models, or experiment ' .
-            'and explore the features of CakePHP and your application.' .
+            'This shell provides a REPL that you can use to interact with ' .
+            'your application in a command line designed to run PHP code. ' .
+            'You can use it to run adhoc queries with your models, or ' .
+            'explore the features of CakePHP and your application.' .
             "\n\n" .
             'You will need to have psysh installed for this Shell to work.'
         );


### PR DESCRIPTION
Using one form of "interact" in the first sentence. Changed "experiment and explore" to only "explore," partly to line the columns, and with the thought that one could perhaps imply the other.