### PR TITLE
Pass middleware config through constructor.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -86,7 +86,7 @@ class Application extends BaseApplication
         $middlewareQueue
             // Catch any exceptions in the lower layers,
             // and make an error page/response
-            ->add(ErrorHandlerMiddleware::class)
+            ->add(new ErrorHandlerMiddleware(null, Configure::read('Error')))
 
             // Handle plugin/theme assets like CakePHP normally does.
             ->add(new AssetMiddleware([


### PR DESCRIPTION
Explicitly passing the config allows user to better understand how the error config is used and they could conditionally modify it if needed.

In 4.x I would like remove direct use of `Configure::read('Error')` in `ErrorHandlerMiddleware::__construct()`.