### PR TITLE
Declare phpunit as dev dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         "cakephp/cakephp-codesniffer": "^3.0",
         "cakephp/debug_kit": "^3.15.0",
         "josegonzalez/dotenv": "3.*",
+        "phpunit/phpunit": "^5|^6",
         "psy/psysh": "@stable"
     },
     "suggest": {
         "markstory/asset_compress": "An asset compression plugin which provides file concatenation and a flexible filter system for preprocessing and minification.",
-        "dereuromark/cakephp-ide-helper": "After baking your code, this keeps your annotations in sync with the code evolving from there on for maximum IDE and PHPStan compatibility.",
-        "phpunit/phpunit": "Allows automated tests to be run without system-wide install."
+        "dereuromark/cakephp-ide-helper": "After baking your code, this keeps your annotations in sync with the code evolving from there on for maximum IDE and PHPStan compatibility."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
CakePHP supports phpunit versions 5.x or 6.x but not 7.x. Declare the
dev dependency as "^5|^6". "^6" would be sufficient, but showing both
5.x and 6.x documents that CakePHP is compatible with both. Fixes #647.
