### PR TITLE
Fix Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,18 @@ language: php
 
 dist: trusty
 
-sudo: false
-
 php:
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
-matrix:
-  fast_finish: true
-
+env:
   global:
     - DEFAULT=1
 
+matrix:
   include:
     - php: 7.0
       env: PHPCS=1 DEFAULT=0
@@ -26,7 +24,6 @@ matrix:
 before_script:
   - if [[ $PHPCS = 1 ]]; then composer require cakephp/cakephp-codesniffer:~2.1; fi
   - if [[ $DEFAULT = 1 ]]; then composer install; fi
-  - if [[ $DEFAULT = 1 ]]; then composer require phpunit/phpunit:"^5.7|^6.0"; fi
   - if [[ $DEFAULT = 1 ]]; then composer run-script post-install-cmd --no-interaction; fi
   - if [[ $PHPSTAN = 1 ]]; then composer require --dev "phpstan/phpstan"; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.2
   - 7.3
 
 env:
@@ -15,10 +14,10 @@ env:
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.2
       env: PHPCS=1 DEFAULT=0
 
-    - php: 7.1
+    - php: 7.2
       env: PHPSTAN=1 DEFAULT=0
 
 before_script:
@@ -30,7 +29,7 @@ before_script:
 script:
   - if [[ $DEFAULT = 1 ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests ./config ./webroot; fi
-  - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -l 5 src; fi
+  - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -l 5 src/; fi
 
 notifications:
   email: false


### PR DESCRIPTION
Travis testing was broken because `DEFAULT=1` was defined in wrong place and Composer/PHPUnit simply skipped.

Additionally:
* Add PHP 7.3.
* Remove `composer require phpunit/phpunit` as it is now in `composer.json`.
* Remove `sudo: false` as it is now [deprecated](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) and ignored.
* Remove `fast_finish: true` as there is no `allow_failures`.
