### PR TITLE
Set the overwrite option to `true` in the (commented) Dotenv initialize

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -52,9 +52,9 @@ use Cake\Utility\Security;
 // if (!env('APP_NAME') && file_exists(CONFIG . '.env')) {
 //     $dotenv = new \josegonzalez\Dotenv\Loader([CONFIG . '.env']);
 //     $dotenv->parse()
-//         ->putenv()
-//         ->toEnv()
-//         ->toServer();
+//         ->putenv(true)
+//         ->toEnv(true)
+//         ->toServer(true);
 // }
 
 /*


### PR DESCRIPTION
See here: https://github.com/josegonzalez/php-dotenv

Making this the default should

1) Be harmless, and
2) Potentially save people some headaches

If you are using a `.env` pattern. Try calling `bin/cake` from within CakePHP itself (via an `exec` of some kind).

It throws `LogicException` because by default it doesn't want to overwrite the variables when it reads the `.env` file again.

The underlying issue is hard to spot when you are running into it, but it is this.