### PR TITLE
Add infos for Postgres

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -250,9 +250,9 @@ return [
             'persistent' => false,
             'host' => 'localhost',
             /*
-             * CakePHP will use the default DB port based on the driver selected
-             * MySQL on MAMP uses port 8889, MAMP users will want to uncomment
-             * the following line and set the port accordingly
+             * CakePHP will use the default DB port based on the driver selected.
+             * For instance, MariaDB/MySQL on MAMP uses port 8889
+             * thus MAMP users will want to uncomment the following line and set the port accordingly
              */
             //'port' => 'non_standard_port_number',
             'username' => 'my_app',
@@ -261,7 +261,7 @@ return [
             /*
              * When using PostgreSQL driver you will need to define the schema otherwise to be able to access/describe tables.
              */
-            //'schema' => 'myapp' 
+            //'schema' => 'myapp',
             /*
              * For MariaDB/MySQL the internal default changed from utf8 to utf8mb4, aka full utf-8 support, in CakePHP 3.6
              */

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -259,7 +259,7 @@ return [
             'password' => 'secret',
             'database' => 'my_app',
             /*
-             * When using PostgreSQL driver you will need to define the schema otherwise to be able to access/describe tables.
+             * When using PostgreSQL driver you will need to define the schema as well.
              */
             //'schema' => 'myapp',
             /*

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -259,7 +259,11 @@ return [
             'password' => 'secret',
             'database' => 'my_app',
             /*
-             * You do not need to set this flag to use full utf-8 encoding (internal default since CakePHP 3.6).
+             * When using PostgreSQL driver you will need to define the schema otherwise to be able to access/describe tables.
+             */
+            //'schema' => 'myapp' 
+            /*
+             * For MariaDB/MySQL the internal default changed from utf8 to utf8mb4, aka full utf-8 support, in CakePHP 3.6
              */
             //'encoding' => 'utf8mb4',
             'timezone' => 'UTC',


### PR DESCRIPTION
Migration from MySQL/MariaDB to Postgres was hard cause of:  `Cannot describe users. It has 0 columns. `
Which is because there was no schema configured.

@lorenzo could/should we make the Datasources.default.schema key readOrFail for the postgres driver?

Aside that issue, these cost some time: Related/Off Topic: For migration from MariaDB to Postgres I collected these infos:
- Move from Auto Increment Integer to UUIDs, also the table class validators needs to be adapted to validate uuid intead of nonNegativInteger for PKs and FKs: https://gist.github.com/inoas/8738e94474ffdb5c568d263ae8601d92
- Export MariaDB, Import Postgres - note: no CURRENT_DATETIME support and dropping MariaDB enums was a good idea https://gist.github.com/inoas/cb7fee79cdde22f265cfa24d478dd97d
