### PR TITLE
PHPDoc | Missing @throws tag

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -35,6 +35,7 @@ class AppController extends Controller
      *
      * e.g. `$this->loadComponent('Security');`
      *
+     * @throws \Exception
      * @return void
      */
     public function initialize()


### PR DESCRIPTION
Correct PHPDoc warning about missing @throws tag