### PR TITLE
Add back required setTemplatePath

### DIFF
--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -53,6 +53,8 @@ class ErrorController extends AppController
     public function beforeRender(EventInterface $event)
     {
         parent::beforeRender($event);
+
+        $this->viewBuilder()->setTemplatePath('Error');
     }
 
     /**


### PR DESCRIPTION
The `setTemplatePath()` is required here, as the `ExceptionRenderer` would else re throw a `MissingTemplateException`, if the error template for the original exception is e.g. `error404`.