### PR TITLE
Add IdeHelper generated annotations.

### DIFF
--- a/templates/Error/error400.php
+++ b/templates/Error/error400.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @var \App\View\AppView $this
+ */
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 

--- a/templates/Error/error500.php
+++ b/templates/Error/error500.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @var \App\View\AppView $this
+ */
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 

--- a/templates/Pages/home.php
+++ b/templates/Pages/home.php
@@ -11,6 +11,7 @@
  * @link      https://cakephp.org CakePHP(tm) Project
  * @since     0.10.0
  * @license   https://opensource.org/licenses/mit-license.php MIT License
+ * @var \App\View\AppView $this
  */
 use Cake\Cache\Cache;
 use Cake\Core\Configure;

--- a/templates/layout/ajax.php
+++ b/templates/layout/ajax.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \App\View\AppView $this
  */
 
 echo $this->fetch('content');

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \App\View\AppView $this
  */
 
 $cakeDescription = 'CakePHP: the rapid development php framework';

--- a/templates/layout/email/html/default.php
+++ b/templates/layout/email/html/default.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \App\View\AppView $this
  */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">

--- a/templates/layout/email/text/default.php
+++ b/templates/layout/email/text/default.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \App\View\AppView $this
  */
 
 echo $this->fetch('content');

--- a/templates/layout/error.php
+++ b/templates/layout/error.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \App\View\AppView $this
  */
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
After upgrading [IdeHelper](https://github.com/dereuromark/cakephp-ide-helper) running it on the app itself showed that several Layout templates are not annotated with the AppView
This makes the methods not clickable. Fixed with this PR.