### PR TITLE
Update error pages

### DIFF
--- a/templates/layout/error.php
+++ b/templates/layout/error.php
@@ -23,26 +23,21 @@
     </title>
     <?= $this->Html->meta('icon') ?>
 
-    <?= $this->Html->css('base.css') ?>
-    <?= $this->Html->css('style.css') ?>
+    <link href="https://fonts.googleapis.com/css?family=Raleway:400,700" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.css">
+
+    <?= $this->Html->css('milligram.min.css') ?>
+    <?= $this->Html->css('cake.css') ?>
 
     <?= $this->fetch('meta') ?>
     <?= $this->fetch('css') ?>
     <?= $this->fetch('script') ?>
 </head>
 <body>
-    <div id="container">
-        <div id="header">
-            <h1><?= __('Error') ?></h1>
-        </div>
-        <div id="content">
-            <?= $this->Flash->render() ?>
-
-            <?= $this->fetch('content') ?>
-        </div>
-        <div id="footer">
-            <?= $this->Html->link(__('Back'), 'javascript:history.back()') ?>
-        </div>
+    <div class="error-container">
+        <?= $this->Flash->render() ?>
+        <?= $this->fetch('content') ?>
+        <?= $this->Html->link(__('Back'), 'javascript:history.back()') ?>
     </div>
 </body>
 </html>


### PR DESCRIPTION
I forgot to add the new style to the debug off error pages.
They look like 

![Screenshot 2019-06-11 at 20 22 41](https://user-images.githubusercontent.com/6617432/59296641-c4fe0980-8c86-11e9-85e7-5508b14b313f.png)

and

![Screenshot 2019-06-11 at 20 22 38](https://user-images.githubusercontent.com/6617432/59296660-cd564480-8c86-11e9-88f8-901241fd8aa1.png)

