### PR TITLE
Removes unused `use` statement in bootstrap

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -33,7 +33,6 @@ use Cake\Cache\Cache;
 use Cake\Console\ConsoleErrorHandler;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\Core\Plugin;
 use Cake\Database\Type;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ErrorHandler;


### PR DESCRIPTION
Plugins are not loaded within `bootstrap.php` anymore.