### PR TITLE
Re-add migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "cakephp/bake": "4.x-dev",
         "cakephp/cakephp-codesniffer": "dev-next",
         "cakephp/debug_kit": "4.x-dev",
+        "cakephp/migrations": "4.x-dev",
         "josegonzalez/dotenv": "3.*",
         "phpunit/phpunit": "^8.0",
         "psy/psysh": "@stable"


### PR DESCRIPTION
Now that we have a 4.x compatible migrations we can add it back to the app skeleton.
