### PR TITLE
Removed composer requirement since covered by composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env: PHPSTAN=1 DEFAULT=0
 
 before_script:
-  - if [[ $DEFAULT = 1 ]]; then composer install; fi
+  - if [[ $DEFAULT = 1 || $PHPCS = 1 ]]; then composer install; fi
   - if [[ $DEFAULT = 1 ]]; then composer run-script post-install-cmd --no-interaction; fi
   - if [[ $PHPSTAN = 1 ]]; then composer require --dev "phpstan/phpstan"; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
       env: PHPSTAN=1 DEFAULT=0
 
 before_script:
-  - if [[ $PHPCS = 1 ]]; then composer require cakephp/cakephp-codesniffer:~2.1; fi
   - if [[ $DEFAULT = 1 ]]; then composer install; fi
   - if [[ $DEFAULT = 1 ]]; then composer run-script post-install-cmd --no-interaction; fi
   - if [[ $PHPSTAN = 1 ]]; then composer require --dev "phpstan/phpstan"; fi


### PR DESCRIPTION
Removed CakePHP Codesniffer from travis.yml, since composer.json requires Codesniffer aswell in Version 3. See https://github.com/cakephp/app/blob/master/composer.json#L16