### PR TITLE
Use proper simple string plugin name.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -46,7 +46,7 @@ class Application extends BaseApplication
          * Debug Kit should not be installed on a production system
          */
         if (Configure::read('debug')) {
-            $this->addPlugin(\DebugKit\Plugin::class);
+            $this->addPlugin('DebugKit');
         }
 
         // Load more plugins here


### PR DESCRIPTION
We shouldnt promote this.
This is super annoying on project level, as every plugin would need aliasing.
The auto fixer adds those to use statements and it gets messy.

Instead, use normal string approach
Additionally, IdeHelper can auto complete the strings here just fine.