### PR TITLE
Add `--stability=dev` flag to allow `dev` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The framework source code can be found here: [cakephp/cakephp](https://github.co
 ## Installation
 
 1. Download [Composer](https://getcomposer.org/doc/00-intro.md) or update `composer self-update`.
-2. Run `php composer.phar create-project --prefer-dist cakephp/app [app_name]`.
+2. Run `php composer.phar create-project --prefer-dist --stability=dev cakephp/app [app_name]`.
 
 If Composer is installed globally, run
 
 ```bash
-composer create-project --prefer-dist cakephp/app:4.x
+composer create-project --prefer-dist --stability=dev cakephp/app:4.x
 ```
 
 In case you want to use a custom app dir name (e.g. `/myapp/`):


### PR DESCRIPTION
By default the composer will try to install the `stable` 4.x version, and in absence of which the error is triggered specifying that the package `cakephp/app` with version 4.x is not available/found.
This happens while 4.x is `dev`, not stable.

Add `--stability=dev` flag to allow `dev` version to be installed by default, until the stable version is released.

