### PR TITLE
Add missing throws tag

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -36,6 +36,7 @@ class AppController extends Controller
      * e.g. `$this->loadComponent('Security');`
      *
      * @return void
+     * @throws \Exception If the component cannot be found
      */
     public function initialize(): void
     {


### PR DESCRIPTION
As the internals of loadComponent can throw an exception it should be documented, so a use can choose to catch it