### PR TITLE
Move interactive code for setting folder permission under it's own method.

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -60,28 +60,7 @@ class Installer
         static::createAppLocalConfig($rootDir, $io);
         static::createWritableDirectories($rootDir, $io);
 
-        // ask if the permissions should be changed
-        if ($io->isInteractive()) {
-            $validator = function ($arg) {
-                if (in_array($arg, ['Y', 'y', 'N', 'n'])) {
-                    return $arg;
-                }
-                throw new Exception('This is not a valid answer. Please choose Y or n.');
-            };
-            $setFolderPermissions = $io->askAndValidate(
-                '<info>Set Folder Permissions ? (Default to Y)</info> [<comment>Y,n</comment>]? ',
-                $validator,
-                10,
-                'Y'
-            );
-
-            if (in_array($setFolderPermissions, ['Y', 'y'])) {
-                static::setFolderPermissions($rootDir, $io);
-            }
-        } else {
-            static::setFolderPermissions($rootDir, $io);
-        }
-
+        static::setFolderPermissions($rootDir, $io);
         static::setSecuritySalt($rootDir, $io);
 
         $class = 'Cake\Codeception\Console\Installer';
@@ -136,6 +115,26 @@ class Installer
      */
     public static function setFolderPermissions($dir, $io)
     {
+        // ask if the permissions should be changed
+        if ($io->isInteractive()) {
+            $validator = function ($arg) {
+                if (in_array($arg, ['Y', 'y', 'N', 'n'])) {
+                    return $arg;
+                }
+                throw new Exception('This is not a valid answer. Please choose Y or n.');
+            };
+            $setFolderPermissions = $io->askAndValidate(
+                '<info>Set Folder Permissions ? (Default to Y)</info> [<comment>Y,n</comment>]? ',
+                $validator,
+                10,
+                'Y'
+            );
+
+            if (in_array($setFolderPermissions, ['n', 'N'])) {
+                return;
+            }
+        }
+
         // Change the permissions on a path and output the results.
         $changePerms = function ($path) use ($io) {
             $currentPerms = fileperms($path) & 0777;


### PR DESCRIPTION
This allows those who don't need permission setting to simply remove the method call.