### PR TITLE
enable in PagesController only to not slow down rest of testsuite

### DIFF
--- a/tests/TestCase/Controller/PagesControllerTest.php
+++ b/tests/TestCase/Controller/PagesControllerTest.php
@@ -30,6 +30,30 @@ class PagesControllerTest extends TestCase
     use IntegrationTestTrait;
 
     /**
+     * setUpBeforeClass method
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        Configure::write('debug', true);
+    }
+
+    /**
+     * tearDownAfterClass method
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        Configure::write('debug', false);
+    }
+
+    /**
      * testMultipleGet method
      *
      * @return void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,6 +35,7 @@ Configure::write('App.fullBaseUrl', 'http://localhost');
 // DebugKit skips settings these connection config if PHP SAPI is CLI / PHPDBG.
 // But since PagesControllerTest is run with debug enabled and DebugKit is loaded
 // in application, without setting up these config DebugKit errors out.
+Configure::write('debug', false);
 ConnectionManager::setConfig('test_debug_kit', [
     'className' => 'Cake\Database\Connection',
     'driver' => 'Cake\Database\Driver\Sqlite',


### PR DESCRIPTION
**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.