### PR TITLE
Removed Security Component initialization

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -33,7 +33,7 @@ class AppController extends Controller
      *
      * Use this method to add common initialization code like loading components.
      *
-     * e.g. `$this->loadComponent('Security');`
+     * e.g. `$this->loadComponent('FormProtection');`
      *
      * @return void
      */
@@ -45,9 +45,9 @@ class AppController extends Controller
         $this->loadComponent('Flash');
 
         /*
-         * Enable the following component for recommended CakePHP security settings.
-         * see https://book.cakephp.org/4/en/controllers/components/security.html
+         * Enable the following component for recommended CakePHP form protection settings.
+         * see https://book.cakephp.org/4/en/controllers/components/form-protection.html
          */
-        //$this->loadComponent('Security');
+        //$this->loadComponent('FormProtection');
     }
 }


### PR DESCRIPTION
Removed Security Component and added FormProtection in app controller. As Security component is deprecated so we should not tell users to use Security component in app controller.

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.