### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!---
+
 **PLEASE NOTE:**
 
 This is only a issue tracker for issues related to the CakePHP Application Skeleton.
@@ -8,3 +10,5 @@ Describe the big picture of your changes here to communicate to the maintainers 
 The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
 
 Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
+
+-->


### PR DESCRIPTION
Could this help to have the warning for PRs, but not the noise when they dont relize that this should be replaced with content?
See e.g. https://github.com/cakephp/app/pull/766