### PR TITLE
Update bake's dependency constraint.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "mobiledetect/mobiledetectlib": "2.*"
     },
     "require-dev": {
-        "cakephp/bake": "^2.0",
+        "cakephp/bake": "^2.0.3",
         "cakephp/cakephp-codesniffer": "^4.0",
         "cakephp/debug_kit": "^4.0",
         "josegonzalez/dotenv": "3.*",

--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,15 @@
         "php": ">=7.2",
         "cakephp/cakephp": "^4.0",
         "cakephp/migrations": "^3.0",
-        "cakephp/plugin-installer": "^1.0",
-        "mobiledetect/mobiledetectlib": "2.*"
+        "cakephp/plugin-installer": "^1.2",
+        "mobiledetect/mobiledetectlib": "^2.8"
     },
     "require-dev": {
         "cakephp/bake": "^2.0.3",
         "cakephp/cakephp-codesniffer": "^4.0",
         "cakephp/debug_kit": "^4.0",
-        "josegonzalez/dotenv": "3.*",
-        "phpunit/phpunit": "^8.0",
+        "josegonzalez/dotenv": "^3.2",
+        "phpunit/phpunit": "^8.5",
         "psy/psysh": "@stable"
     },
     "suggest": {


### PR DESCRIPTION
This ensures stable version of TwigView is used.