### PR TITLE
Only update to 4.0 patch releases.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "cakephp/bake": "^2.0.3",
-        "cakephp/cakephp-codesniffer": "^4.0",
+        "cakephp/cakephp-codesniffer": "~4.0.0",
         "cakephp/debug_kit": "^4.0",
         "josegonzalez/dotenv": "^3.2",
         "phpunit/phpunit": "^8.5",


### PR DESCRIPTION
It's best if people upgrade to new core minors explicitly after reviewing migration guide.