### PR TITLE
Update comment around loading app_local.php

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -83,7 +83,7 @@ try {
 
 /*
  * Load an environment local configuration file to provide overrides to your configuration.
- * Notice: For security reasons app_local.php will not be included in your git repo.
+ * Notice: For security reasons app_local.php **should not** be included in your git repo.
  */
 if (file_exists(CONFIG . 'app_local.php')) {
     Configure::load('app_local', 'default');


### PR DESCRIPTION
Change `will not be` to `should not be` included in your git repo. We can't guarantee people won't just copy the file and not the git attributes so this shouldn't sound so absolute.