### PR TITLE
Remove link to certification page

### DIFF
--- a/templates/Pages/home.php
+++ b/templates/Pages/home.php
@@ -213,7 +213,6 @@ $cakeDescription = 'CakePHP: the rapid development PHP framework';
                         <h3>Training and Certification</h3>
                         <a target="_blank" href="https://cakefoundation.org/">Cake Software Foundation</a>
                         <a target="_blank" href="https://training.cakephp.org/">CakePHP Training</a>
-                        <a target="_blank" href="https://certification.cakephp.org/">CakePHP Certification</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Certification is only offered for CakePHP 2.x, it doesn't make sense to show the link in Version 4 until the certification programme has been updated.
