### PR TITLE
Updating Deprecated setMethods()

### DIFF
--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -57,7 +57,7 @@ class ApplicationTest extends IntegrationTestCase
 
         $app = $this->getMockBuilder(Application::class)
             ->setConstructorArgs([dirname(dirname(__DIR__)) . '/config'])
-            ->setMethods(['addPlugin'])
+            ->onlyMethods(['addPlugin'])
             ->getMock();
 
         $app->method('addPlugin')


### PR DESCRIPTION
Updating Deprecated `setMethods` when mocking Application for testing. 

See https://github.com/sebastianbergmann/phpunit/pull/3687