### PR TITLE
Override Milligram fonts and anchor elements

### DIFF
--- a/webroot/css/cake.css
+++ b/webroot/css/cake.css
@@ -1,7 +1,46 @@
 /* Miligram overrides */
-a {
+body {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 400;
+}
+
+.top-nav-links,
+.side-nav,
+h1, h2, h3, h4, h5, h6 {
     font-family: "Raleway", sans-serif;
-    color: #404041;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-weight: 400;
+    color: #363637;
+}
+
+a {
+    color:#2f85ae;
+    -webkit-transition:all 0.2s linear;
+    transition:all 0.2s linear;
+}
+
+a:hover,
+a:focus,
+a:active  {
+    color:#2a6496;
+    -webkit-transition:all 0.2s easeout;
+    transition:all 0.2s ease-out;
+}
+
+.side-nav a,
+.top-nav-links a,
+th a,
+.actions a {
+    color: #606c76;
+}
+
+.side-nav a:hover,
+.side-nav a:focus,
+.actions a:hover,
+.actions a:focus {
+    color:#2f85ae;
 }
 
 /* Utility */


### PR DESCRIPTION
Override the fonts and weights set by Milligram. Use colours for anchor elements that are more accessible. Match the styles with other CakePHP sites like https://book.cakephp.org
