### PR TITLE
Replace deprecated class import.

### DIFF
--- a/src/Command/ConsoleCommand.php
+++ b/src/Command/ConsoleCommand.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace App\Command;
 
+use Cake\Command\Command;
 use Cake\Console\Arguments;
-use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Log\Log;


### PR DESCRIPTION
This replaces the  `Cake\Console\Command` class name (deprecated in CakePHP 4.0.0) with `Cake\Command\Command` in `src/Command/ConsoleCommand.php`.
