### PR TITLE
Upgraded cakephp-codesniffer to ~4.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "cakephp/bake": "^2.0.3",
-        "cakephp/cakephp-codesniffer": "~4.0.0",
+        "cakephp/cakephp-codesniffer": "~4.1.0",
         "cakephp/debug_kit": "^4.0",
         "josegonzalez/dotenv": "^3.2",
         "phpunit/phpunit": "^8.5",
@@ -43,8 +43,8 @@
             "@test",
             "@cs-check"
         ],
-        "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/",
-        "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/ tests/",
+        "cs-check": "phpcs --colors -p  src/ tests/",
+        "cs-fix": "phpcbf --colors -p src/ tests/",
         "stan": "phpstan analyse src/",
         "test": "phpunit --colors=always"
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="App">
+    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
+
+    <rule ref="CakePHP"/>
+</ruleset>


### PR DESCRIPTION
Not sure if we want to add a default phpcs.xml file for users, but seems like it might be cleaner.