### PR TITLE
[4.next] REPL Convenience Functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,10 @@
         "psr-4": {
             "App\\Test\\": "tests/",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
-        }
+        },
+        "files": [
+            "src/Command/repl_functions.php"
+        ]
     },
     "scripts": {
         "post-install-cmd": "App\\Console\\Installer::postInstall",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,8 @@
 parameters:
     level: 7
     checkMissingIterableValueType: false
+    autoload_files:
+        - config/paths.php
     excludes_analyse:
         - src/Console/Installer.php
     ignoreErrors:

--- a/src/Command/ConsoleCommand.php
+++ b/src/Command/ConsoleCommand.php
@@ -51,6 +51,8 @@ class ConsoleCommand extends Command
             return static::CODE_ERROR;
         }
 
+        include 'repl_functions.php';
+
         $io->out("You can exit with <info>`CTRL-C`</info> or <info>`exit`</info>");
         $io->out('');
 

--- a/src/Command/repl_functions.php
+++ b/src/Command/repl_functions.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.2.9
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Psy\Shell as PsyShell;
+
+if (!function_exists('breakpoint')) {
+    /**
+     * Command to return the eval-able code to startup PsySH in interactive debugger
+     * Works the same way as eval(\Psy\sh());
+     * psy/psysh must be loaded in your project
+     *
+     * @link http://psysh.org/
+     * ```
+     * eval(breakpoint());
+     * ```
+     * @return string|null
+     */
+    function breakpoint(): ?string
+    {
+        if ((PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') && class_exists(PsyShell::class)) {
+            return 'extract(\Psy\Shell::debug(get_defined_vars(), isset($this) ? $this : null));';
+        }
+        trigger_error(
+            'psy/psysh must be installed and you must be in a CLI environment to use the breakpoint function',
+            E_USER_WARNING
+        );
+
+        return null;
+    }
+}
+
+if (!function_exists('table') && (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg')) {
+    /**
+     * REPL convenience function to load a table
+     *
+     * Do **NOT** use this function in your app or plugin code,
+     * it is meant only for use in the CakePHP interactive console (REPL).
+     *
+     * @param string $alias The alias name you want to get.
+     * @param array $options The options you want to build the table with.
+     * @return \Cake\ORM\Table
+     */
+    function table(string $alias, array $options = []): Table
+    {
+        return TableRegistry::getTableLocator()->get($alias, $options);
+    }
+}

--- a/tests/TestCase/Command/ReplFunctionsTest.php
+++ b/tests/TestCase/Command/ReplFunctionsTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BasicsTest file
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace App\Test\Command\TestCase;
+
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+require_once APP . 'Command' . DS . 'repl_functions.php';
+
+/**
+ * REPL functions tests
+ */
+class ReplFunctionsTest extends TestCase
+{
+    /**
+     * Tests the table() function returns a table object
+     *
+     * @return void
+     */
+    public function testTable()
+    {
+        $table = \table('Table');
+        $this->assertInstanceOf(Table::class, $table);
+    }
+}


### PR DESCRIPTION
This is the result of the discussions in https://github.com/cakephp/cakephp/pull/14490

This in combination with https://github.com/cakephp/cakephp/pull/14491 is an alternative to https://github.com/cakephp/cakephp/pull/14490.

We might want to think about extracting the REPL to its own plugin. We would move the files from this PR with it.