### PR TITLE
Remove unreachable statement

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,3 @@ parameters:
     checkMissingIterableValueType: false
     excludes_analyse:
         - src/Console/Installer.php
-    ignoreErrors:
-        -
-            message: "#^Unreachable statement \\- code above always terminates\\.$#"
-            count: 1
-            path: src/Controller/PagesController.php

--- a/src/Controller/PagesController.php
+++ b/src/Controller/PagesController.php
@@ -69,7 +69,5 @@ class PagesController extends AppController
             }
             throw new NotFoundException();
         }
-
-        return $this->render();
     }
 }


### PR DESCRIPTION
This is a very small fix.
I found a line that couldn't be executed in `PagesController::display()`, so cleaned up it.

NOTE:
In [this commit](https://github.com/cakephp/app/commit/0bc840e92dd4c2a18ffcc8b354fa663964367c5d), this action has been updated to return in early.