### PR TITLE
Fix route deprecation warning

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -48,7 +48,7 @@ $routes->setRouteClass(DashedRoute::class);
 $routes->scope('/', function (RouteBuilder $builder) {
     // Register scoped middleware for in scopes.
     $builder->registerMiddleware('csrf', new CsrfProtectionMiddleware([
-        'httpOnly' => true,
+        'httponly' => true,
     ]));
 
     /*


### PR DESCRIPTION
Fix a deprecation warning that is issued stating that the mixed-case "httpOnly" option is deprecated in favor of the all lowercase "httponly" option.
