### PR TITLE
Centralize configuration for cache,log and database driver settings

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,14 +1,17 @@
 <?php
 
-use Cake\Cache\Engine\FileEngine as CacheEngine;
+use Cake\Cache\Engine\FileEngine;
 use Cake\Database\Connection;
-use Cake\Database\Driver\Mysql as DatabaseDriver;
+use Cake\Database\Driver\Mysql;
 use Cake\Error\ExceptionRenderer;
-use Cake\Log\Engine\FileLog as LogEngine;
+use Cake\Log\Engine\FileLog;
 use Cake\Mailer\Transport\MailTransport;
 
 $appName = 'myapp';
 $cachePrefix = "${appName}_";
+$logEngine = FileLog::class;
+$cacheEngine = FileEngine::class;
+$databaseDriver = Mysql::class;
 
 return [
     /*
@@ -100,7 +103,7 @@ return [
      */
     'Cache' => [
         'default' => [
-            'className' => CacheEngine::class,
+            'className' => $cacheEngine,
             'path' => CACHE,
             'prefix' => $cachePrefix,
             'url' => env('CACHE_DEFAULT_URL', null),
@@ -113,7 +116,7 @@ return [
          * If you set 'className' => 'Null' core cache will be disabled.
          */
         '_cake_core_' => [
-            'className' => CacheEngine::class,
+            'className' => $cacheEngine,
             'path' => CACHE . 'persistent' . DS,
             'prefix' => $cachePrefix .'cake_core_',
             'serialize' => true,
@@ -128,7 +131,7 @@ return [
          * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
          */
         '_cake_model_' => [
-            'className' => CacheEngine::class,
+            'className' => $cacheEngine,
             'path' => CACHE . 'models' . DS,
             'prefix' => $cachePrefix . 'cake_model_',
             'serialize' => true,
@@ -142,7 +145,7 @@ return [
          * Duration will be set to '+2 seconds' in bootstrap.php when debug = true
          */
         '_cake_routes_' => [
-            'className' => CacheEngine::class,
+            'className' => $cacheEngine,
             'path' => CACHE,
             'prefix' => $cachePrefix . 'cake_routes_',
             'serialize' => true,
@@ -291,7 +294,7 @@ return [
          */
         'default' => [
             'className' => Connection::class,
-            'driver' => DatabaseDriver::class,
+            'driver' => $databaseDriver,
             'persistent' => false,
             'timezone' => 'UTC',
 
@@ -351,7 +354,7 @@ return [
      */
     'Log' => [
         'debug' => [
-            'className' => LogEngine::class,
+            'className' => $logEngine,
             'path' => LOGS,
             'file' => 'debug',
             'url' => env('LOG_DEBUG_URL', null),
@@ -359,7 +362,7 @@ return [
             'levels' => ['notice', 'info', 'debug'],
         ],
         'error' => [
-            'className' => LogEngine::class,
+            'className' => $logEngine,
             'path' => LOGS,
             'file' => 'error',
             'url' => env('LOG_ERROR_URL', null),
@@ -368,7 +371,7 @@ return [
         ],
         // To enable this dedicated query log, you need set your datasource's log flag to true
         'queries' => [
-            'className' => LogEngine::class,
+            'className' => $logEngine,
             'path' => LOGS,
             'file' => 'queries',
             'url' => env('LOG_QUERIES_URL', null),

--- a/config/app.php
+++ b/config/app.php
@@ -1,11 +1,14 @@
 <?php
 
-use Cake\Cache\Engine\FileEngine;
+use Cake\Cache\Engine\FileEngine as CacheEngine;
 use Cake\Database\Connection;
-use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Mysql as DatabaseDriver;
 use Cake\Error\ExceptionRenderer;
-use Cake\Log\Engine\FileLog;
+use Cake\Log\Engine\FileLog as LogEngine;
 use Cake\Mailer\Transport\MailTransport;
+
+$appName = 'myapp';
+$cachePrefix = "${appName}_";
 
 return [
     /*
@@ -97,8 +100,9 @@ return [
      */
     'Cache' => [
         'default' => [
-            'className' => FileEngine::class,
+            'className' => CacheEngine::class,
             'path' => CACHE,
+            'prefix' => $cachePrefix,
             'url' => env('CACHE_DEFAULT_URL', null),
         ],
 
@@ -109,9 +113,9 @@ return [
          * If you set 'className' => 'Null' core cache will be disabled.
          */
         '_cake_core_' => [
-            'className' => FileEngine::class,
-            'prefix' => 'myapp_cake_core_',
+            'className' => CacheEngine::class,
             'path' => CACHE . 'persistent' . DS,
+            'prefix' => $cachePrefix .'cake_core_',
             'serialize' => true,
             'duration' => '+1 years',
             'url' => env('CACHE_CAKECORE_URL', null),
@@ -124,9 +128,9 @@ return [
          * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
          */
         '_cake_model_' => [
-            'className' => FileEngine::class,
-            'prefix' => 'myapp_cake_model_',
+            'className' => CacheEngine::class,
             'path' => CACHE . 'models' . DS,
+            'prefix' => $cachePrefix . 'cake_model_',
             'serialize' => true,
             'duration' => '+1 years',
             'url' => env('CACHE_CAKEMODEL_URL', null),
@@ -138,9 +142,9 @@ return [
          * Duration will be set to '+2 seconds' in bootstrap.php when debug = true
          */
         '_cake_routes_' => [
-            'className' => FileEngine::class,
-            'prefix' => 'myapp_cake_routes_',
+            'className' => CacheEngine::class,
             'path' => CACHE,
+            'prefix' => $cachePrefix . 'cake_routes_',
             'serialize' => true,
             'duration' => '+1 years',
             'url' => env('CACHE_CAKEROUTES_URL', null),
@@ -287,7 +291,7 @@ return [
          */
         'default' => [
             'className' => Connection::class,
-            'driver' => Mysql::class,
+            'driver' => DatabaseDriver::class,
             'persistent' => false,
             'timezone' => 'UTC',
 
@@ -347,7 +351,7 @@ return [
      */
     'Log' => [
         'debug' => [
-            'className' => FileLog::class,
+            'className' => LogEngine::class,
             'path' => LOGS,
             'file' => 'debug',
             'url' => env('LOG_DEBUG_URL', null),
@@ -355,7 +359,7 @@ return [
             'levels' => ['notice', 'info', 'debug'],
         ],
         'error' => [
-            'className' => FileLog::class,
+            'className' => LogEngine::class,
             'path' => LOGS,
             'file' => 'error',
             'url' => env('LOG_ERROR_URL', null),
@@ -364,7 +368,7 @@ return [
         ],
         // To enable this dedicated query log, you need set your datasource's log flag to true
         'queries' => [
-            'className' => FileLog::class,
+            'className' => LogEngine::class,
             'path' => LOGS,
             'file' => 'queries',
             'url' => env('LOG_QUERIES_URL', null),


### PR DESCRIPTION
It should be easier to change these configuration to the top of file so that we don't have to fish out the values below.
Having the $cachePrefix as variable also avoids forgotting to change a prefix in one of the config.