### PR TITLE
Use string for time type

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -34,6 +34,8 @@ require CORE_PATH . 'config' . DS . 'bootstrap.php';
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
+use Cake\Database\TypeFactory;
+use Cake\Database\Type\StringType;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ConsoleErrorHandler;
 use Cake\Error\ErrorHandler;
@@ -203,7 +205,9 @@ ServerRequest::addDetector('tablet', function ($request) {
 //    ->useMutable();
 // \Cake\Database\TypeFactory::build('timestamptimezone')
 //    ->useMutable();
-\Cake\Database\TypeFactory::map('time', \Cake\Database\Type\StringType::class);
+
+// There is no time-specific type in Cake
+TypeFactory::map('time', StringType::class);
 
 /*
  * Custom Inflector rules, can be set to correctly pluralize or singularize

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -187,22 +187,23 @@ ServerRequest::addDetector('tablet', function ($request) {
  * locale specific date formats. For details see
  * @link https://book.cakephp.org/4/en/core-libraries/internationalization-and-localization.html#parsing-localized-datetime-data
  */
-// TypeFactory::build('time')
+// \Cake\Database\TypeFactory::build('time')
 //    ->useMutable();
-// TypeFactory::build('date')
+// \Cake\Database\TypeFactory::build('date')
 //    ->useMutable();
-// TypeFactory::build('datetime')
+// \Cake\Database\TypeFactory::build('datetime')
 //    ->useMutable();
-// TypeFactory::build('timestamp')
+// \Cake\Database\TypeFactory::build('timestamp')
 //    ->useMutable();
-// TypeFactory::build('datetimefractional')
+// \Cake\Database\TypeFactory::build('datetimefractional')
 //    ->useMutable();
-// TypeFactory::build('timestampfractional')
+// \Cake\Database\TypeFactory::build('timestampfractional')
 //    ->useMutable();
-// TypeFactory::build('datetimetimezone')
+// \Cake\Database\TypeFactory::build('datetimetimezone')
 //    ->useMutable();
-// TypeFactory::build('timestamptimezone')
+// \Cake\Database\TypeFactory::build('timestamptimezone')
 //    ->useMutable();
+\Cake\Database\TypeFactory::map('time', \Cake\Database\Type\StringType::class);
 
 /*
  * Custom Inflector rules, can be set to correctly pluralize or singularize


### PR DESCRIPTION
See current bugs and hacks needed as per https://github.com/cakephp/chronos/issues/102#issuecomment-726750246
and also discussion of https://github.com/cakephp/cakephp/issues/13440

It seems until a good value object is found, a string default seems like the right choice for now.

If so, should this go into 4.next?