### PR TITLE
Not consitent strings in cake.pot

### DIFF
--- a/templates/Error/error500.php
+++ b/templates/Error/error500.php
@@ -38,7 +38,7 @@ if (Configure::read('debug')) :
     $this->end();
 endif;
 ?>
-<h2><?= __d('cake', 'An Internal Error Has Occurred') ?></h2>
+<h2><?= __d('cake', 'An Internal Error Has Occurred.') ?></h2>
 <p class="error">
     <strong><?= __d('cake', 'Error') ?>: </strong>
     <?= h($message) ?>


### PR DESCRIPTION
#: Error/error500.php:41
msgid "An Internal Error Has Occurred"
msgstr ""

#: Error/ExceptionRenderer.php:340
msgid "An Internal Error Has Occurred."
msgstr ""

<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
