### PR TITLE
Use DIRECTORY_SEPARATOR to load paths.php

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 /*
  * Configure paths required to find CakePHP + general filepath constants
  */
-require __DIR__ . '/paths.php';
+require __DIR__ . DIRECTORY_SEPARATOR . 'paths.php';
 
 /*
  * Bootstrap CakePHP.


### PR DESCRIPTION
Even though `DS` isn't defined yet, we can use the platform-specific separator here.
