### PR TITLE
Use DS to load bootstrap_cli.php

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -133,7 +133,7 @@ if ($isCli) {
  * Include the CLI bootstrap overrides.
  */
 if ($isCli) {
-    require __DIR__ . '/bootstrap_cli.php';
+    require CONFIG . 'bootstrap_cli.php';
 }
 
 /*


### PR DESCRIPTION
We should be able to use platform-specific directory separator to load bootstrap_cli.php.

Updated to use `CONFIG` path instead of raw `__DIR__` which is only needed to load paths.php.
