### PR TITLE
Only update debug and error logs if they exist

### DIFF
--- a/config/bootstrap_cli.php
+++ b/config/bootstrap_cli.php
@@ -27,5 +27,9 @@ use Cake\Core\Configure;
 //Configure::write('App.fullBaseUrl', php_uname('n'));
 
 // Set logs to different files so they don't have permission conflicts.
-Configure::write('Log.debug.file', 'cli-debug');
-Configure::write('Log.error.file', 'cli-error');
+if (Configure::check('Log.debug')) {
+    Configure::write('Log.debug.file', 'cli-debug');
+}
+if (Configure::check('Log.error')) {
+    Configure::write('Log.error.file', 'cli-error');
+}


### PR DESCRIPTION
This prevents an error when loading an invalid log config.