### PR TITLE
Bump plugin-installer to 1.3 for composer 1 and 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=5.6",
         "cakephp/cakephp": "3.9.*",
         "cakephp/migrations": "^2.0.0",
-        "cakephp/plugin-installer": "^1.0",
+        "cakephp/plugin-installer": "^1.3",
         "mobiledetect/mobiledetectlib": "2.*"
     },
     "require-dev": {


### PR DESCRIPTION
This version supports composer v1 and v2 with php 5.6+.
