### PR TITLE
Check if HTTP_HOST is not already set

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,7 +30,9 @@ require dirname(__DIR__) . '/config/bootstrap.php';
 
 $_SERVER['PHP_SELF'] = '/';
 
-Configure::write('App.fullBaseUrl', 'http://localhost');
+if (empty($_SERVER['HTTP_HOST'])) {
+    Configure::write('App.fullBaseUrl', 'http://localhost');
+}
 
 // DebugKit skips settings these connection config if PHP SAPI is CLI / PHPDBG.
 // But since PagesControllerTest is run with debug enabled and DebugKit is loaded


### PR DESCRIPTION
Check if HTTP_HOST is set (through phpunit.xml for instance) and only set it to the default when the HTTP_HOST is empty or when it does not exist.

Linked issue in CakePHP Framework issue tracker: https://github.com/cakephp/cakephp/issues/15584

<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
