### PR TITLE
Remove references to enabling mutable datetime objects.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -182,31 +182,27 @@ ServerRequest::addDetector('tablet', function ($request) {
 });
 
 /*
- * You can set whether the ORM uses immutable or mutable Time types.
- * The default changed in 4.0 to immutable types. You can uncomment
- * below to switch back to mutable types.
- *
  * You can enable default locale format parsing by adding calls
  * to `useLocaleParser()`. This enables the automatic conversion of
  * locale specific date formats. For details see
  * @link https://book.cakephp.org/4/en/core-libraries/internationalization-and-localization.html#parsing-localized-datetime-data
  */
 // \Cake\Database\TypeFactory::build('time')
-//    ->useMutable();
+//    ->useLocaleParser();
 // \Cake\Database\TypeFactory::build('date')
-//    ->useMutable();
+//    ->useLocaleParser();
 // \Cake\Database\TypeFactory::build('datetime')
-//    ->useMutable();
+//    ->useLocaleParser();
 // \Cake\Database\TypeFactory::build('timestamp')
-//    ->useMutable();
+//    ->useLocaleParser();
 // \Cake\Database\TypeFactory::build('datetimefractional')
-//    ->useMutable();
+//    ->useLocaleParser();
 // \Cake\Database\TypeFactory::build('timestampfractional')
-//    ->useMutable();
+//    ->useLocaleParser();
 // \Cake\Database\TypeFactory::build('datetimetimezone')
-//    ->useMutable();
+//    ->useLocaleParser();
 // \Cake\Database\TypeFactory::build('timestamptimezone')
-//    ->useMutable();
+//    ->useLocaleParser();
 
 // There is no time-specific type in Cake
 TypeFactory::map('time', StringType::class);


### PR DESCRIPTION
They are deprecated in 4.3.

<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
