### PR TITLE
Update cakephp-codesniffer to latest 4.x release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "cakephp/bake": "^2.3",
         "cakephp/repl": "^0.1",
-        "cakephp/cakephp-codesniffer": "~4.2.0",
+        "cakephp/cakephp-codesniffer": "^4.5",
         "cakephp/debug_kit": "^4.4",
         "josegonzalez/dotenv": "^3.2",
         "phpunit/phpunit": "~8.5.0 || ^9.3"


### PR DESCRIPTION
I don't see why this should be stuck on 4.2.
