### PR TITLE
Assert existence of each plugin at testBootstrap

### DIFF
--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -40,7 +40,6 @@ class ApplicationTest extends IntegrationTestCase
         $app->bootstrap();
         $plugins = $app->getPlugins();
 
-        $this->assertCount(4, $plugins);
         $this->assertTrue($plugins->has('Cake/Repl'), 'plugins has Cake/Repl');
         $this->assertTrue($plugins->has('Bake'), 'plugins has Bake');
         $this->assertTrue($plugins->has('DebugKit'), 'plugins has DebugKit');

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -41,10 +41,10 @@ class ApplicationTest extends IntegrationTestCase
         $plugins = $app->getPlugins();
 
         $this->assertCount(4, $plugins);
-        $this->assertSame('Cake/Repl', $plugins->get('Cake/Repl')->getName());
-        $this->assertSame('Bake', $plugins->get('Bake')->getName());
-        $this->assertSame('DebugKit', $plugins->get('DebugKit')->getName());
-        $this->assertSame('Migrations', $plugins->get('Migrations')->getName());
+        $this->assertTrue($plugins->has('Cake/Repl'), 'plugins has Cake/Repl');
+        $this->assertTrue($plugins->has('Bake'), 'plugins has Bake');
+        $this->assertTrue($plugins->has('DebugKit'), 'plugins has DebugKit');
+        $this->assertTrue($plugins->has('Migrations'), 'plugins has Migrations');
     }
 
     /**


### PR DESCRIPTION
fixes #867

PluginCollection::get() creates the plugin if not added, so it was nonsense.

And don't assert count of plugins.
