### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db
 #######################
 # PHPUnit
 .phpunit.result.cache
+tests.sqlite
 # vim
 *~
 *.swp


### PR DESCRIPTION
This seems necessary with a fresh install and no db set up.
Or can we somehow move this generation of this file to the tmp folder?
Might be cleaner.