### PR TITLE
Fix .gitignore so potential icon assets are tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@
 ._*
 .Spotlight-V100
 .Trashes
-Icon?
+# Icon must end with two \r
+Icon
 ehthumbs.db
 Thumbs.db
 .directory


### PR DESCRIPTION
This fixes issue cakephp/cakephp/issues/16138 by using GitHub's .gitignore [template suggestion](https://github.com/github/gitignore/blob/master/Global/macOS.gitignore#L7)