### PR TITLE
Add switch to enable usage of `X-Forwarded-Proto`.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -142,8 +142,18 @@ if ($isCli) {
  */
 $fullBaseUrl = Configure::read('App.fullBaseUrl');
 if (!$fullBaseUrl) {
+    /*
+     * When using proxies or load balancers, SSL/TLS connections might
+     * get terminated before reaching the server. If you trust the proxy,
+     * you can enable `$trustProxy` to rely on the `X-Forwarded-Proto`
+     * header to determine whether to generate URLs using `https`.
+     *
+     * See also https://book.cakephp.org/4/en/controllers/request-response.html#trusting-proxy-headers
+     */
+    $trustProxy = false;
+
     $s = null;
-    if (env('HTTPS')) {
+    if (env('HTTPS') || ($trustProxy && env('HTTP_X_FORWARDED_PROTO') === 'https')) {
         $s = 's';
     }
 


### PR DESCRIPTION
I've seen this problem come up quite a few times on SO and Slack, usually from people using cloud services like AWS or Azure.

And while I'd rather hardcode the protocol, or even the complete full base URL, this might not always be applicable, or people might simply be unaware of the source or the problem.

refs cakephp/cakephp#16393