### PR TITLE
improve error message if debug_kit doesn't work due to TLD whitelist

### DIFF
--- a/templates/Pages/home.php
+++ b/templates/Pages/home.php
@@ -40,7 +40,7 @@ $checkConnection = function (string $name) {
             $error = 'Try adding your current <b>top level domain</b> to the
                 <a href="https://book.cakephp.org/debugkit/4/en/index.html#configuration" target="_blank">DebugKit.safeTld</a>
             config and reload.';
-            if (!in_array('sqlite', PDO::getAvailableDrivers())) {
+            if (!in_array('sqlite', \PDO::getAvailableDrivers())) {
                 $error .= '<br />You need to install the PHP extension <code>pdo_sqlite</code> so DebugKit can work properly.';
             }
         }

--- a/templates/Pages/home.php
+++ b/templates/Pages/home.php
@@ -40,6 +40,9 @@ $checkConnection = function (string $name) {
             $error = 'Try adding your current <b>top level domain</b> to the
                 <a href="https://book.cakephp.org/debugkit/4/en/index.html#configuration" target="_blank">DebugKit.safeTld</a>
             config and reload.';
+            if (!in_array('sqlite', PDO::getAvailableDrivers())) {
+                $error .= '<br />You need to install the PHP extension <code>pdo_sqlite</code> so DebugKit can work properly.';
+            }
         }
     }
 

--- a/templates/Pages/home.php
+++ b/templates/Pages/home.php
@@ -185,7 +185,7 @@ endif;
                             <?php if ($result['connected']) : ?>
                                 <li class="bullet success">DebugKit can connect to the database.</li>
                             <?php else : ?>
-                                <li class="bullet problem">DebugKit is <strong>not</strong> able to connect to the database.<br /><?= $result['error'] ?></li>
+                                <li class="bullet problem">There are configuration problems present which need to be fixed:<br /><?= $result['error'] ?></li>
                             <?php endif; ?>
                         <?php else : ?>
                             <li class="bullet problem">DebugKit is <strong>not</strong> loaded.</li>

--- a/templates/Pages/home.php
+++ b/templates/Pages/home.php
@@ -36,6 +36,11 @@ $checkConnection = function (string $name) {
                 $error .= '<br />' . $attributes['message'];
             }
         }
+        if ($name === 'debug_kit') {
+            $error = 'Try adding your current <b>top level domain</b> to the
+                <a href="https://book.cakephp.org/debugkit/4/en/index.html#configuration" target="_blank">DebugKit.safeTld</a>
+            config and reload.';
+        }
     }
 
     return compact('connected', 'error');


### PR DESCRIPTION
Refs: https://github.com/cakephp/debug_kit/issues/894

Currently the app template shows a not telling error 
```
DebugKit is not able to connect to the database. 
The datasource configuration "debug_kit" was not found.
```
if the DebugKit's Toolbar Service is disabled.

The Toolbar Service can only be enabled via the following scenarios:
* debug mode is on **AND** the current TLD is one of `'localhost', 'invalid', 'test', 'example', 'local'`
* debug mode is on **AND** the current TLD is configured via `DebugKit.safeTld`
* debug mode is off and `forceEnable` is on

All other scenarios will result in a disabled DebugKit and therefore the not telling error from above.
Therefore all new CakePHP installations which are directly created on a server (and will therefore most likely have a "real" TLD to call that app) will result in a failing DebugKit.

This adjustment will show a more telling error which looks like this:
<img width="535" alt="image" src="https://user-images.githubusercontent.com/9105243/199234195-4168f880-91e0-4f92-ab08-9c395f7758ce.png">

I first thought to add some more conditions to the if but in the end that home template will only work when Debug Mode is on anyways due to https://github.com/cakephp/app/blob/4.x/templates/Pages/home.php#L44

Therefore if we get a connection error from the connection named `debug_kit` in there we must have debug mode on but the ToolbarService is not enabled.

If the User has no `sqlite` php extension installed DebugKit itself will log a warning as can be seen [here](https://github.com/cakephp/debug_kit/blob/4.x/config/bootstrap.php#L21), so this is not our job here as well. Or should we add an extra check + message here as well?

We could also add a default config block like this
```
    'DebugKit' => [
        //'safeTld' => ['com']
    ]
```
to the generated ` app_local.php` so people have an easier time to adjust that.