### PR TITLE
Emails (Mailers) use the core view by default

### DIFF
--- a/templates/email/html/default.php
+++ b/templates/email/html/default.php
@@ -11,7 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \App\View\AppView $this
+ * @var \\Cake\View\View $this
  * @var string $content
  */
 

--- a/templates/email/html/default.php
+++ b/templates/email/html/default.php
@@ -11,7 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \\Cake\View\View $this
+ * @var \Cake\View\View $this
  * @var string $content
  */
 

--- a/templates/email/text/default.php
+++ b/templates/email/text/default.php
@@ -11,7 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \App\View\AppView $this
+ * @var \Cake\View\View $this
  * @var string $content
  */
 


### PR DESCRIPTION
If no custom renderer is set.

https://api.cakephp.org/4.4/class-Cake.Mailer.Mailer.html#viewBuilder() ->
https://api.cakephp.org/4.4/class-Cake.Mailer.Mailer.html#getRenderer() ->
https://api.cakephp.org/4.4/class-Cake.Mailer.Renderer.html#createView() ->
https://api.cakephp.org/4.4/trait-Cake.View.ViewVarsTrait.html#createView()

---

With the previous documentation one would assume that helpers etc. are available which aren't if not configured manually.