### PR TITLE
5.x: fix debug_kit version string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "cakephp/bake": "dev-cake5",
         "cakephp/cakephp-codesniffer": "^5.0",
-        "cakephp/debug_kit": "dev-cake5",
+        "cakephp/debug_kit": "5.x-dev",
         "josegonzalez/dotenv": "^3.2",
         "phpunit/phpunit": "^9.5.19"
     },


### PR DESCRIPTION
The cake5 branch name for the debug_kit plugin seems to have changed.
See https://github.com/cakephp/debug_kit/tree/5.x