### PR TITLE
Move tests.sqlite to tmp

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -70,7 +70,7 @@ return [
             'password' => 'secret',
             'database' => 'test_myapp',
             //'schema' => 'myapp',
-            'url' => env('DATABASE_TEST_URL', 'sqlite://127.0.0.1/tests.sqlite'),
+            'url' => env('DATABASE_TEST_URL', 'sqlite://127.0.0.1/tmp/tests.sqlite'),
         ],
     ],
 


### PR DESCRIPTION
~~The test connection url defaults to `env('DATABASE_TEST_URL', 'sqlite://127.0.0.1/tests.sqlite')`, hence ignoring the generated SQLite file might be useful.~~

Moving the `tests.sqlite` into `tmp/` by default, so it lives next to `debug_kit.sqlite` and is ignored by default.