### PR TITLE
Migrations 4.x-dev instead of dev-cake5(removed)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=8.1",
         "cakephp/cakephp": "5.x-dev",
-        "cakephp/migrations": "dev-cake5",
+        "cakephp/migrations": "4.x-dev",
         "cakephp/plugin-installer": "^2.0",
         "mobiledetect/mobiledetectlib": "^3.74"
     },


### PR DESCRIPTION
Use correct version for cakephp/migrations. The branch cake5 was removed. Branch 4.x is compatible with CakePHP 5