### PR TITLE
4.x: remove loading repl plugin in bootstrap cli

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -124,7 +124,6 @@ class Application extends BaseApplication
      */
     protected function bootstrapCli(): void
     {
-        $this->addOptionalPlugin('Cake/Repl');
         $this->addOptionalPlugin('Bake');
 
         $this->addPlugin('Migrations');


### PR DESCRIPTION
cakephp/repl isn't being installed by default anymore, therefore we shouldn't load it by default as well.
Refs: https://github.com/cakephp/app/pull/878