### PR TITLE
4.next: add example on how to set custom date/time format

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -221,3 +221,9 @@ TypeFactory::map('time', StringType::class);
 //Inflector::rules('plural', ['/^(inflect)or$/i' => '\1ables']);
 //Inflector::rules('irregular', ['red' => 'redlings']);
 //Inflector::rules('uninflected', ['dontinflectme']);
+
+// set a custom date and time format
+// see https://book.cakephp.org/4/en/core-libraries/time.html#setting-the-default-locale-and-format-string
+// and https://unicode-org.github.io/icu/userguide/format_parse/datetime/#datetime-format-syntax
+//\Cake\I18n\FrozenDate::setToStringFormat('dd.MM.yyyy');
+//\Cake\I18n\FrozenTime::setToStringFormat('dd.MM.yyyy HH:mm');


### PR DESCRIPTION
Users often don't know where/how to set a custom date/time format - as well as to use the ICU format instead of the PHP format.

Should we also add the mutable classes as well? I personall don't think so.