### PR TITLE
5.x: remove Time DBType map to StringType

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -215,9 +215,6 @@ ServerRequest::addDetector('tablet', function ($request) {
 // \Cake\Database\TypeFactory::build('timestamptimezone')
 //    ->useLocaleParser();
 
-// There is no time-specific type in Cake
-TypeFactory::map('time', StringType::class);
-
 /*
  * Custom Inflector rules, can be set to correctly pluralize or singularize
  * table, model, controller names or whatever other string is passed to the


### PR DESCRIPTION
We now have a proper `TimeType`
Refs: https://github.com/cakephp/cakephp/pull/17137
