### PR TITLE
5.x: remove static method in routes.php

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -21,71 +21,73 @@
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 
+/**
+ * @var \Cake\Routing\RouteBuilder $routes
+ */
+
 use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 
-return static function (RouteBuilder $routes) {
+/*
+ * The default class to use for all routes
+ *
+ * The following route classes are supplied with CakePHP and are appropriate
+ * to set as the default:
+ *
+ * - Route
+ * - InflectedRoute
+ * - DashedRoute
+ *
+ * If no call is made to `Router::defaultRouteClass()`, the class used is
+ * `Route` (`Cake\Routing\Route\Route`)
+ *
+ * Note that `Route` does not do any inflections on URLs which will result in
+ * inconsistently cased URLs when used with `{plugin}`, `{controller}` and
+ * `{action}` markers.
+ */
+$routes->setRouteClass(DashedRoute::class);
+
+$routes->scope('/', function (RouteBuilder $builder) {
     /*
-     * The default class to use for all routes
-     *
-     * The following route classes are supplied with CakePHP and are appropriate
-     * to set as the default:
-     *
-     * - Route
-     * - InflectedRoute
-     * - DashedRoute
-     *
-     * If no call is made to `Router::defaultRouteClass()`, the class used is
-     * `Route` (`Cake\Routing\Route\Route`)
-     *
-     * Note that `Route` does not do any inflections on URLs which will result in
-     * inconsistently cased URLs when used with `{plugin}`, `{controller}` and
-     * `{action}` markers.
+     * Here, we are connecting '/' (base path) to a controller called 'Pages',
+     * its action called 'display', and we pass a param to select the view file
+     * to use (in this case, templates/Pages/home.php)...
      */
-    $routes->setRouteClass(DashedRoute::class);
-
-    $routes->scope('/', function (RouteBuilder $builder) {
-        /*
-         * Here, we are connecting '/' (base path) to a controller called 'Pages',
-         * its action called 'display', and we pass a param to select the view file
-         * to use (in this case, templates/Pages/home.php)...
-         */
-        $builder->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
-
-        /*
-         * ...and connect the rest of 'Pages' controller's URLs.
-         */
-        $builder->connect('/pages/*', 'Pages::display');
-
-        /*
-         * Connect catchall routes for all controllers.
-         *
-         * The `fallbacks` method is a shortcut for
-         *
-         * ```
-         * $builder->connect('/{controller}', ['action' => 'index']);
-         * $builder->connect('/{controller}/{action}/*', []);
-         * ```
-         *
-         * You can remove these routes once you've connected the
-         * routes you want in your application.
-         */
-        $builder->fallbacks();
-    });
+    $builder->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
 
     /*
-     * If you need a different set of middleware or none at all,
-     * open new scope and define routes there.
-     *
-     * ```
-     * $routes->scope('/api', function (RouteBuilder $builder) {
-     *     // No $builder->applyMiddleware() here.
-     *
-     *     // Parse specified extensions from URLs
-     *     // $builder->setExtensions(['json', 'xml']);
-     *
-     *     // Connect API actions here.
-     * });
-     * ```
+     * ...and connect the rest of 'Pages' controller's URLs.
      */
-};
+    $builder->connect('/pages/*', 'Pages::display');
+
+    /*
+     * Connect catchall routes for all controllers.
+     *
+     * The `fallbacks` method is a shortcut for
+     *
+     * ```
+     * $builder->connect('/{controller}', ['action' => 'index']);
+     * $builder->connect('/{controller}/{action}/*', []);
+     * ```
+     *
+     * You can remove these routes once you've connected the
+     * routes you want in your application.
+     */
+    $builder->fallbacks();
+});
+
+/*
+ * If you need a different set of middleware or none at all,
+ * open new scope and define routes there.
+ *
+ * ```
+ * $routes->scope('/api', function (RouteBuilder $builder) {
+ *     // No $builder->applyMiddleware() here.
+ *
+ *     // Parse specified extensions from URLs
+ *     // $builder->setExtensions(['json', 'xml']);
+ *
+ *     // Connect API actions here.
+ * });
+ * ```
+ */


### PR DESCRIPTION
This is my proposed version of how the routes.php should look like.

Why?

Depending on the application one has to build middlewares inside the routes.php
Some middlewares need the application instance like our own [AuthenticationMiddleware](https://github.com/cakephp/authentication/blob/3.x/src/Middleware/AuthenticationMiddleware.php#L50)

E.g. having only some routes which need authentication and not all routes.

But accessing `$this` inside a static function is not allowed. Passing on `$this` via 
```
return static function (RouteBuilder $routes) use ($this)
``` 
is also not possible.

So one would have to build the objects outside of the static method and pass them through, which is kind of bad imho.

If we only added that static method so IDE's can have auto-completetion for the available RouteBuilder methods this is in my opinion the better solution.