### PR TITLE
Remove `static` keyword from the function in routes.php.

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -24,7 +24,11 @@
 use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 
-return static function (RouteBuilder $routes) {
+/**
+ * This file is loaded in the context of the `Application` class. So you can
+ * `$this` to reference the application class instance if required.
+ */
+return function (RouteBuilder $routes) {
     /*
      * The default class to use for all routes
      *

--- a/config/routes.php
+++ b/config/routes.php
@@ -24,9 +24,10 @@
 use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 
-/**
- * This file is loaded in the context of the `Application` class. So you can
- * `$this` to reference the application class instance if required.
+/*
+ * This file is loaded in the context of the `Application` class.
+  * So you can use  `$this` to reference the application class instance
+  * if required.
  */
 return function (RouteBuilder $routes) {
     /*


### PR DESCRIPTION
This allows using `$this` in the function to reference the application class instance. This is required for cases like building an AuthencationMiddleware instance.

<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
