### PR TITLE
Use file config instead.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       run: composer install
 
     - name: Run PHP CodeSniffer
-      run: vendor/bin/phpcs --report=checkstyle src/ tests/ | cs2pr
+      run: vendor/bin/phpcs --report=checkstyle | cs2pr
 
     - name: Run phpstan
       if: always()

--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,8 @@
             "@test",
             "@cs-check"
         ],
-        "cs-check": "phpcs --colors -p  src/ tests/",
-        "cs-fix": "phpcbf --colors -p src/ tests/",
-        "stan": "phpstan analyse",
+        "cs-check": "phpcs --colors -p",
+        "cs-fix": "phpcbf --colors -p",
         "test": "phpunit --colors=always"
     },
     "prefer-stable": true,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,4 +3,7 @@
     <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
 
     <rule ref="CakePHP"/>
+
+    <file>src/</file>
+    <file>tests/</file>
 </ruleset>


### PR DESCRIPTION
When installing a new 5.x I noticed that this doesnt quite follow dry conventions
This fixes it.

It also has a further positive side effect:

Using composer script you can also allow a single file/folder to be checked quickly, e.g.

    composer cs-c src/Console/
    
etc