### PR TITLE
Ignore return type hints in `src/Command`

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,7 @@
 
     <rule ref="CakePHP"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>*/src/Command/*</exclude-pattern>
         <exclude-pattern>*/src/Controller/*</exclude-pattern>
     </rule>
 


### PR DESCRIPTION
PHPCS will complain about missing return-type hints when you bake your first command. 

```php
Method \App\Command\AppCommand::execute() does not have native return type hint for its return value but it should be possible to add it based on @return
    |       |     annotation "int|null|void".
```

PHPCBF then adds `: int|null|null` 🤔 