### PR TITLE
5.x: update mobiledetect lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cakephp/cakephp": "^5.0.1",
         "cakephp/migrations": "^4.0.0",
         "cakephp/plugin-installer": "^2.0",
-        "mobiledetect/mobiledetectlib": "^3.74"
+        "mobiledetect/mobiledetectlib": "^4.8"
     },
     "require-dev": {
         "cakephp/bake": "^3.0.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "cakephp/cakephp": "^5.0.1",
         "cakephp/migrations": "^4.0.0",
         "cakephp/plugin-installer": "^2.0",
-        "mobiledetect/mobiledetectlib": "^4.8"
+        "mobiledetect/mobiledetectlib": "^4.8.03"
     },
     "require-dev": {
         "cakephp/bake": "^3.0.0",

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -183,11 +183,13 @@ Security::setSalt(Configure::consume('Security.salt'));
  */
 ServerRequest::addDetector('mobile', function ($request) {
     $detector = new \Detection\MobileDetect();
+    $detector->setUserAgent($request->getEnv('HTTP_USER_AGENT'));
 
     return $detector->isMobile();
 });
 ServerRequest::addDetector('tablet', function ($request) {
     $detector = new \Detection\MobileDetect();
+    $detector->setUserAgent($request->getEnv('HTTP_USER_AGENT'));
 
     return $detector->isTablet();
 });

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -183,13 +183,11 @@ Security::setSalt(Configure::consume('Security.salt'));
  */
 ServerRequest::addDetector('mobile', function ($request) {
     $detector = new \Detection\MobileDetect();
-    $detector->setUserAgent($request->getEnv('HTTP_USER_AGENT'));
 
     return $detector->isMobile();
 });
 ServerRequest::addDetector('tablet', function ($request) {
     $detector = new \Detection\MobileDetect();
-    $detector->setUserAgent($request->getEnv('HTTP_USER_AGENT'));
 
     return $detector->isTablet();
 });


### PR DESCRIPTION
Refs: https://github.com/cakephp/app/pull/976

this requires users to adjust their `config/bootstrap.php` do add 1 line per detector:
```
$detector->setUserAgent($request->getEnv('HTTP_USER_AGENT'));
```