### PR TITLE
Chronos setTestNow for apps test harness default

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  * @license   https://opensource.org/licenses/mit-license.php MIT License
  */
 
+use Cake\Chronos\Chronos;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Migrations\TestSuite\Migrator;
@@ -46,6 +47,9 @@ ConnectionManager::setConfig('test_debug_kit', [
 ]);
 
 ConnectionManager::alias('test_debug_kit', 'debug_kit');
+
+// Fixate now to avoid one-second-leap-issues
+Chronos::setTestNow(Chronos::now());
 
 // Fixate sessionid early on, as php7.2+
 // does not allow the sessionid to be set after stdout


### PR DESCRIPTION
Shouldnt we include that as best practice in general?