### PR TITLE
Clean up error templates.

### DIFF
--- a/templates/Error/error400.php
+++ b/templates/Error/error400.php
@@ -1,12 +1,10 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var \Cake\Database\StatementInterface $error
  * @var string $message
  * @var string $url
  */
 use Cake\Core\Configure;
-use Cake\Error\Debugger;
 
 $this->layout = 'error';
 
@@ -17,21 +15,7 @@ if (Configure::read('debug')) :
     $this->assign('templateName', 'error400.php');
 
     $this->start('file');
-?>
-<?php if (!empty($error->queryString)) : ?>
-    <p class="notice">
-        <strong>SQL Query: </strong>
-        <?= h($error->queryString) ?>
-    </p>
-<?php endif; ?>
-<?php if (!empty($error->params)) : ?>
-    <strong>SQL Query Params: </strong>
-    <?php Debugger::dump($error->params) ?>
-<?php endif; ?>
-
-<?php
     echo $this->element('auto_table_warning');
-
     $this->end();
 endif;
 ?>

--- a/templates/Error/error500.php
+++ b/templates/Error/error500.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var \Cake\Database\StatementInterface $error
  * @var string $message
  * @var string $url
  */
@@ -18,16 +17,6 @@ if (Configure::read('debug')) :
 
     $this->start('file');
 ?>
-<?php if (!empty($error->queryString)) : ?>
-    <p class="notice">
-        <strong>SQL Query: </strong>
-        <?= h($error->queryString) ?>
-    </p>
-<?php endif; ?>
-<?php if (!empty($error->params)) : ?>
-    <strong>SQL Query Params: </strong>
-    <?php Debugger::dump($error->params) ?>
-<?php endif; ?>
 <?php if ($error instanceof Error) : ?>
     <?php $file = $error->getFile() ?>
     <?php $line = $error->getLine() ?>


### PR DESCRIPTION
With debug enabled the WebExceptionRenderer switches the template to pdo_error.php in case of a PDOException, so having checks for SQL query related stuff in debug mode is redundant.

Refs #970, closes #992.

<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
