### PR TITLE
Update bootstrap.php

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -103,8 +103,6 @@ if (file_exists(CONFIG . 'app_local.php')) {
 if (Configure::read('debug')) {
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
     Configure::write('Cache._cake_core_.duration', '+2 minutes');
-    // disable router cache during development
-    Configure::write('Cache._cake_routes_.duration', '+2 seconds');
 }
 
 /*


### PR DESCRIPTION
Remove the setting for the `_cake_routes_` cache since it has been removed in the CakePHP 5.

Reference: https://book.cakephp.org/4/en/appendices/4-4-migration-guide.html#routing
