### PR TITLE
5.next: Allow DebugKit config to be set in environment variables

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -412,4 +412,9 @@ return [
     'Session' => [
         'defaults' => 'php',
     ],
+    'DebugKit' => [
+        'forceEnable' => filter_var(env('DEBUG_KIT_FORCE_ENABLE', false), FILTER_VALIDATE_BOOLEAN),
+        'safeTld' => env('DEBUG_KIT_SAFE_TLD'),
+        'ignoreAuthorization' => filter_var(env('DEBUG_KIT_IGNORE_AUTHORIZATION', false), FILTER_VALIDATE_BOOLEAN),
+    ],
 ];


### PR DESCRIPTION
Please refer to: https://github.com/cakephp/debug_kit/issues/997