### PR TITLE
4.x: Allow DebugKit config to be set in environment variables

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -421,4 +421,9 @@ return [
     'Session' => [
         'defaults' => 'php',
     ],
+    'DebugKit' => [
+        'forceEnable' => filter_var(env('DEBUG_KIT_FORCE_ENABLE', false), FILTER_VALIDATE_BOOLEAN),
+        'safeTld' => env('DEBUG_KIT_SAFE_TLD', null),
+        'ignoreAuthorization' => env('DEBUG_KIT_IGNORE_AUTHORIZATION', false)
+    ],
 ];


### PR DESCRIPTION
Please refer to: https://github.com/cakephp/debug_kit/issues/997