### PR TITLE
remove `_cake_routes_` config

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -101,8 +101,6 @@ if (file_exists(CONFIG . 'app_local.php')) {
 if (Configure::read('debug')) {
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
     Configure::write('Cache._cake_translations_.duration', '+2 minutes');
-    // disable router cache during development
-    Configure::write('Cache._cake_routes_.duration', '+2 seconds');
 }
 
 /*


### PR DESCRIPTION
No idea why its present again because it was removed in https://github.com/cakephp/app/pull/995 but here we go again