### PR TITLE
Add description to DebugKit configuration options

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -412,6 +412,30 @@ return [
     'Session' => [
         'defaults' => 'php',
     ],
+
+    /**
+     * DebugKit configuration.
+     *
+     * Contains an array of configurations to apply to the DebugKit plugin, if loaded.
+     * Documentation: https://book.cakephp.org/debugkit/5/en/index.html#configuration
+     *
+     * ## Options
+     *
+     *  - `panels` - Enable or disable panels. The key is the panel name, and the value is true to enable,
+     *     or false to disable.
+     *  - `includeSchemaReflection` - Set to true to enable logging of schema reflection queries. Disabled by default.
+     *  - `safeTld` - Set an array of whitelisted TLDs for local development.
+     *  - `forceEnable` - Force DebugKit to display. Careful with this, it is usually safer to simply whitelist
+     *     your local TLDs.
+     *  - `ignorePathsPattern` - Regex pattern (including delimiter) to ignore paths.
+     *     DebugKit won’t save data for request URLs that match this regex.
+     *  - `ignoreAuthorization` - Set to true to ignore Cake Authorization plugin for DebugKit requests.
+     *     Disabled by default.
+     *  - `maxDepth` - Defines how many levels of nested data should be shown in general for debug output.
+     *     Default is 5. WARNING: Increasing the max depth level can lead to an out of memory error.
+     *  - `variablesPanelMaxDepth` - Defines how many levels of nested data should be shown in the variables tab.
+     *     Default is 5. WARNING: Increasing the max depth level can lead to an out of memory error.
+     */
     'DebugKit' => [
         'forceEnable' => filter_var(env('DEBUG_KIT_FORCE_ENABLE', false), FILTER_VALIDATE_BOOLEAN),
         'safeTld' => env('DEBUG_KIT_SAFE_TLD', null),

--- a/config/app.php
+++ b/config/app.php
@@ -439,6 +439,6 @@ return [
     'DebugKit' => [
         'forceEnable' => filter_var(env('DEBUG_KIT_FORCE_ENABLE', false), FILTER_VALIDATE_BOOLEAN),
         'safeTld' => env('DEBUG_KIT_SAFE_TLD', null),
-        'ignoreAuthorization' => env('DEBUG_KIT_IGNORE_AUTHORIZATION', false)
+        'ignoreAuthorization' => env('DEBUG_KIT_IGNORE_AUTHORIZATION', false),
     ],
 ];


### PR DESCRIPTION
This adds commented descriptions for the DebugKit plugin configuration options in `app.php`. In #1002, a contributor added DebugKit configurations, which is great, but it lacked the same attention to comments that the rest of the app.php configurations contain. 

All possible options are commented. The configuration options and descriptions were copied from the [documentation ](https://book.cakephp.org/debugkit/5/en/index.html#configuration).

Also, it added a trailing comma to the existing configuration made in #1002. 