### PR TITLE
Allow PHPUnit 12.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "cakephp/cakephp-codesniffer": "^5.0",
         "cakephp/debug_kit": "^5.0.0",
         "josegonzalez/dotenv": "^4.0",
-        "phpunit/phpunit": "^10.5.5 || ^11.1.3"
+        "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.1"
     },
     "suggest": {
         "cakephp/repl": "Console tools for a REPL interface for CakePHP applications.",


### PR DESCRIPTION
I already use 12 in my apps, this should be doable by now to allow if PHP version locally is the correct minimum and composer installs it.