### PR TITLE
Update ErrorController.php return docblock

### DIFF
--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -39,7 +39,7 @@ class ErrorController extends AppController
      * beforeFilter callback.
      *
      * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event Event.
-     * @return \Cake\Http\Response|null|void
+     * @return void
      */
     public function beforeFilter(EventInterface $event)
     {
@@ -49,7 +49,7 @@ class ErrorController extends AppController
      * beforeRender callback.
      *
      * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event Event.
-     * @return \Cake\Http\Response|null|void
+     * @return void
      */
     public function beforeRender(EventInterface $event)
     {
@@ -62,7 +62,7 @@ class ErrorController extends AppController
      * afterFilter callback.
      *
      * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event Event.
-     * @return \Cake\Http\Response|null|void
+     * @return void
      */
     public function afterFilter(EventInterface $event)
     {


### PR DESCRIPTION
Change due to https://github.com/cakephp/cakephp/commit/0b0e3dccd81560e9f2b6b28780c3b9e8a857c861 changed in 5.2.3

Returning values for event callbacks is deprecated.