### PR TITLE
use $this->setLayout instead of $this->layout

### DIFF
--- a/templates/Error/error400.php
+++ b/templates/Error/error400.php
@@ -6,10 +6,10 @@
  */
 use Cake\Core\Configure;
 
-$this->layout = 'error';
+$this->setLayout('error');
 
 if (Configure::read('debug')) :
-    $this->layout = 'dev_error';
+    $this->setLayout('dev_error');
 
     $this->assign('title', $message);
     $this->assign('templateName', 'error400.php');

--- a/templates/Error/error500.php
+++ b/templates/Error/error500.php
@@ -7,10 +7,10 @@
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
-$this->layout = 'error';
+$this->setLayout('error');
 
 if (Configure::read('debug')) :
-    $this->layout = 'dev_error';
+    $this->setLayout('dev_error');
 
     $this->assign('title', $message);
     $this->assign('templateName', 'error500.php');


### PR DESCRIPTION
Use $this->setLayout instead of $this->layout fixing global scope property modification notices by language server on error templates.