### PR TITLE
use 1min

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -99,8 +99,8 @@ if (file_exists(CONFIG . 'app_local.php')) {
  * When debug = true the metadata cache should only last for a short time.
  */
 if (Configure::read('debug')) {
-    Configure::write('Cache._cake_model_.duration', '+2 minutes');
-    Configure::write('Cache._cake_translations_.duration', '+2 minutes');
+    Configure::write('Cache._cake_model_.duration', '+1 minute');
+    Configure::write('Cache._cake_translations_.duration', '+1 minute');
 }
 
 /*


### PR DESCRIPTION
Use sensible one for actual development
it is rather free of costs locally, and maybe we should even default to 10 seconds or so, prevents people from being confused when doing changes, including composer update.