### PR TITLE
Security: Prevent Host Header Injection attacks

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -18,6 +18,9 @@ export DEBUG="true"
 export APP_ENCODING="UTF-8"
 export APP_DEFAULT_LOCALE="en_US"
 export APP_DEFAULT_TIMEZONE="UTC"
+# SECURITY: Set this to your domain to prevent Host Header Injection attacks
+# This is REQUIRED in production for password resets and other security features
+export APP_FULL_BASE_URL="https://yourdomain.com"
 export SECURITY_SALT="__SALT__"
 
 # Uncomment these to define cache configuration via environment variables.

--- a/config/app.php
+++ b/config/app.php
@@ -59,7 +59,7 @@ return [
         'webroot' => 'webroot',
         'wwwRoot' => WWW_ROOT,
         //'baseUrl' => env('SCRIPT_NAME'),
-        'fullBaseUrl' => env('APP_FULL_BASE_URL'),
+        'fullBaseUrl' => env('APP_FULL_BASE_URL', false),
         'imageBaseUrl' => 'img/',
         'cssBaseUrl' => 'css/',
         'jsBaseUrl' => 'js/',

--- a/config/app.php
+++ b/config/app.php
@@ -36,10 +36,12 @@ return [
      *      /.htaccess
      *      /webroot/.htaccess
      *   And uncomment the baseUrl key below.
-     * - fullBaseUrl - A base URL to use for absolute links. When set to false (default)
-     *   CakePHP generates required value based on `HTTP_HOST` environment variable.
-     *   However, you can define it manually to optimize performance or if you
-     *   are concerned about people manipulating the `Host` header.
+     * - fullBaseUrl - SECURITY: A base URL to use for absolute links.
+     *   IMPORTANT: This MUST be set in production to prevent Host Header Injection attacks
+     *   that can compromise password reset and other security-critical features.
+     *   Set this via APP_FULL_BASE_URL environment variable or directly in config.
+     *   Example: 'https://yourdomain.com'
+     *   When not set, the application will throw an exception in production mode.
      * - imageBaseUrl - Web path to the public images/ directory under webroot.
      * - cssBaseUrl - Web path to the public css/ directory under webroot.
      * - jsBaseUrl - Web path to the public js/ directory under webroot.
@@ -57,7 +59,7 @@ return [
         'webroot' => 'webroot',
         'wwwRoot' => WWW_ROOT,
         //'baseUrl' => env('SCRIPT_NAME'),
-        'fullBaseUrl' => false,
+        'fullBaseUrl' => env('APP_FULL_BASE_URL'),
         'imageBaseUrl' => 'img/',
         'cssBaseUrl' => 'css/',
         'jsBaseUrl' => 'js/',

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -158,7 +158,13 @@ if (PHP_SAPI === 'cli') {
  */
 $fullBaseUrl = Configure::read('App.fullBaseUrl');
 if (!$fullBaseUrl) {
-    if (!Configure::read('debug')) {
+    $httpHost = env('HTTP_HOST');
+
+    /*
+     * Only enforce fullBaseUrl requirement when we're in a web request context.
+     * This allows CLI tools (like PHPStan) to load the bootstrap without throwing.
+     */
+    if (!Configure::read('debug') && $httpHost) {
         throw new \Cake\Core\Exception\CakeException(
             'SECURITY: App.fullBaseUrl is not configured. ' .
             'This is required in production to prevent Host Header Injection attacks. ' .
@@ -170,13 +176,11 @@ if (!$fullBaseUrl) {
      * Development mode fallback: Use HTTP_HOST for convenience.
      * WARNING: This is ONLY safe in development. Never use this pattern in production!
      */
-    $s = null;
-    if (env('HTTPS')) {
-        $s = 's';
-    }
-
-    $httpHost = env('HTTP_HOST');
     if ($httpHost) {
+        $s = null;
+        if (env('HTTPS')) {
+            $s = 's';
+        }
         $fullBaseUrl = 'http' . $s . '://' . $httpHost;
     }
     unset($httpHost, $s);

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -144,24 +144,34 @@ if (PHP_SAPI === 'cli') {
 }
 
 /*
- * Set the full base URL.
+ * SECURITY: Validate and set the full base URL.
  * This URL is used as the base of all absolute links.
- * Can be very useful for CLI/Commandline applications.
+ *
+ * IMPORTANT: In production, App.fullBaseUrl MUST be explicitly configured to prevent
+ * Host Header Injection attacks. Relying on the HTTP_HOST header can allow attackers
+ * to hijack password reset tokens and other security-critical operations.
+ *
+ * Set APP_FULL_BASE_URL in your environment variables or configure App.fullBaseUrl
+ * in config/app.php or config/app_local.php
+ *
+ * Example: APP_FULL_BASE_URL=https://yourdomain.com
  */
 $fullBaseUrl = Configure::read('App.fullBaseUrl');
 if (!$fullBaseUrl) {
-    /*
-     * When using proxies or load balancers, SSL/TLS connections might
-     * get terminated before reaching the server. If you trust the proxy,
-     * you can enable `$trustProxy` to rely on the `X-Forwarded-Proto`
-     * header to determine whether to generate URLs using `https`.
-     *
-     * See also https://book.cakephp.org/5/en/controllers/request-response.html#trusting-proxy-headers
-     */
-    $trustProxy = false;
+    if (!Configure::read('debug')) {
+        throw new \Cake\Core\Exception\CakeException(
+            'SECURITY: App.fullBaseUrl is not configured. ' .
+            'This is required in production to prevent Host Header Injection attacks. ' .
+            'Set APP_FULL_BASE_URL environment variable or configure App.fullBaseUrl in config/app.php'
+        );
+    }
 
+    /*
+     * Development mode fallback: Use HTTP_HOST for convenience.
+     * WARNING: This is ONLY safe in development. Never use this pattern in production!
+     */
     $s = null;
-    if (env('HTTPS') || ($trustProxy && env('HTTP_X_FORWARDED_PROTO') === 'https')) {
+    if (env('HTTPS')) {
         $s = 's';
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a **critical security vulnerability** that allows Host Header Injection attacks, which can be exploited to hijack password reset tokens and compromise user accounts.

### The Vulnerability

The current implementation in `config/bootstrap.php` (lines 168-170) dynamically sets `App.fullBaseUrl` from the `HTTP_HOST` header when not configured:

```php
$httpHost = env('HTTP_HOST');
if ($httpHost) {
    $fullBaseUrl = 'http' . $s . '://' . $httpHost;  // ⚠️ Trusts attacker input!
}
```

### Attack Scenario

1. Attacker sends password reset request with malicious Host header: `Host: attacker.com`
2. Application generates reset URL: `http://attacker.com/users/reset_password/valid-token-123`
3. Victim receives email and clicks the malicious link
4. Attacker captures the valid reset token from their server logs
5. Attacker uses stolen token on legitimate domain to reset victim's password → **Account takeover**

### The Fix

**1. Changed `config/app.php`:**
- Set `App.fullBaseUrl` to use `APP_FULL_BASE_URL` environment variable (instead of `false`)
- Enhanced security documentation explaining the risk
- Added clear configuration instructions

**2. Enhanced `config/bootstrap.php`:**
- **Production mode**: Throws exception if `App.fullBaseUrl` is not configured
- **Development mode**: Keeps HTTP_HOST fallback for convenience (with explicit warning)
- Added comprehensive security comments

**3. Updated `config/.env.example`:**
- Added `APP_FULL_BASE_URL` configuration with security documentation
- Provides example value for developers

## Impact

### Development
✅ **No breaking changes** - HTTP_HOST fallback still works in debug mode

### Production  
⚠️ **Applications MUST configure APP_FULL_BASE_URL** or will fail with clear error:
```
SECURITY: App.fullBaseUrl is not configured. 
This is required in production to prevent Host Header Injection attacks.
Set APP_FULL_BASE_URL environment variable or configure App.fullBaseUrl in config/app.php
```

This is intentional to force proper security configuration in production environments.

As this only applies to new apps, this is BC. current apps are most likely vulnerable in many cases, though.
Maybe debug kit or sth could warn here.

## Configuration Options

Developers can configure this in multiple ways:

**Option 1: Environment Variable (Recommended)**
```bash
APP_FULL_BASE_URL=https://yourdomain.com
```

**Option 2: config/app(_local).php**
```php
'App' => [
    'fullBaseUrl' => 'https://yourdomain.com',
]
```

## Testing

Manual testing performed:
- ✅ Development mode with debug=true: Works as before (uses HTTP_HOST)
- ✅ Production mode without config: Throws clear security exception
- ✅ Production mode with config: Works correctly with configured URL

## References

- [OWASP: Host Header Injection](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection)
- [PortSwigger: Host Header Attacks](https://portswigger.net/web-security/host-header)
- [CakePHP Documentation: fullBaseUrl](https://book.cakephp.org/5/en/development/configuration.html)

## Related Security Concern

The existing comment in `config/app.php` (line 42) already mentions "if you are concerned about people manipulating the Host header" but didn't enforce it. This PR makes that concern actionable by requiring explicit configuration in production.
