### PR TITLE
Move Host Header Injection check to middleware

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -35,7 +35,6 @@ require CORE_PATH . 'config' . DS . 'bootstrap.php';
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\Core\Exception\CakeException;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ErrorTrap;
 use Cake\Error\ExceptionTrap;
@@ -146,12 +145,11 @@ if (PHP_SAPI === 'cli') {
 }
 
 /*
- * SECURITY: Validate and set the full base URL.
- * This URL is used as the base of all absolute links.
+ * Set the full base URL for the application.
  *
- * IMPORTANT: In production, App.fullBaseUrl MUST be explicitly configured to prevent
- * Host Header Injection attacks. Relying on the HTTP_HOST header can allow attackers
- * to hijack password reset tokens and other security-critical operations.
+ * SECURITY: In production, App.fullBaseUrl MUST be explicitly configured to prevent
+ * Host Header Injection attacks. The HostHeaderMiddleware enforces this requirement
+ * and validates incoming Host headers against the configured value.
  *
  * Set APP_FULL_BASE_URL in your environment variables or configure App.fullBaseUrl
  * in config/app.php or config/app_local.php
@@ -163,20 +161,9 @@ if (!$fullBaseUrl) {
     $httpHost = env('HTTP_HOST');
 
     /*
-     * Only enforce fullBaseUrl requirement when we're in a web request context.
-     * This allows CLI tools (like PHPStan) to load the bootstrap without throwing.
-     */
-    if (!Configure::read('debug') && $httpHost) {
-        throw new CakeException(
-            'SECURITY: App.fullBaseUrl is not configured. ' .
-            'This is required in production to prevent Host Header Injection attacks. ' .
-            'Set APP_FULL_BASE_URL environment variable or configure App.fullBaseUrl in config/app.php',
-        );
-    }
-
-    /*
      * Development mode fallback: Use HTTP_HOST for convenience.
-     * WARNING: This is ONLY safe in development. Never use this pattern in production!
+     * WARNING: This is ONLY safe in development. In production, the
+     * HostHeaderMiddleware will reject requests when fullBaseUrl is not configured.
      */
     if ($httpHost) {
         $s = null;

--- a/src/Application.php
+++ b/src/Application.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace App;
 
+use App\Middleware\HostHeaderMiddleware;
 use Cake\Core\Configure;
 use Cake\Core\ContainerInterface;
 use Cake\Datasource\FactoryLocator;
@@ -65,6 +66,11 @@ class Application extends BaseApplication
             // Catch any exceptions in the lower layers,
             // and make an error page/response
             ->add(new ErrorHandlerMiddleware(Configure::read('Error'), $this))
+
+            // Validate Host header to prevent Host Header Injection attacks.
+            // In production, ensures App.fullBaseUrl is configured and validates
+            // the incoming Host header against it.
+            ->add(new HostHeaderMiddleware())
 
             // Handle plugin/theme assets like CakePHP normally does.
             ->add(new AssetMiddleware([

--- a/src/Middleware/HostHeaderMiddleware.php
+++ b/src/Middleware/HostHeaderMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\InternalErrorException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Middleware to validate Host header and prevent Host Header Injection attacks.
+ *
+ * In production, this middleware ensures that App.fullBaseUrl is configured
+ * and validates incoming Host headers against it. This prevents attackers
+ * from manipulating password reset links and other security-critical URLs.
+ *
+ * @see https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/17-Testing_for_Host_Header_Injection
+ */
+class HostHeaderMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process the request and validate the Host header.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
+     * @return \Psr\Http\Message\ResponseInterface A response.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (Configure::read('debug')) {
+            return $handler->handle($request);
+        }
+
+        $fullBaseUrl = Configure::read('App.fullBaseUrl');
+        if (!$fullBaseUrl) {
+            throw new InternalErrorException(
+                'SECURITY: App.fullBaseUrl is not configured. ' .
+                'This is required in production to prevent Host Header Injection attacks. ' .
+                'Set APP_FULL_BASE_URL environment variable or configure App.fullBaseUrl in config/app.php',
+            );
+        }
+
+        $configuredHost = parse_url($fullBaseUrl, PHP_URL_HOST);
+        $requestHost = $request->getUri()->getHost();
+
+        if ($configuredHost && $requestHost && strtolower($configuredHost) !== strtolower($requestHost)) {
+            throw new BadRequestException(
+                'Invalid Host header. Request host does not match configured application host.',
+            );
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace App\Test\TestCase;
 
 use App\Application;
+use App\Middleware\HostHeaderMiddleware;
 use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\MiddlewareQueue;
@@ -78,8 +79,10 @@ class ApplicationTest extends TestCase
 
         $this->assertInstanceOf(ErrorHandlerMiddleware::class, $middleware->current());
         $middleware->seek(1);
-        $this->assertInstanceOf(AssetMiddleware::class, $middleware->current());
+        $this->assertInstanceOf(HostHeaderMiddleware::class, $middleware->current());
         $middleware->seek(2);
+        $this->assertInstanceOf(AssetMiddleware::class, $middleware->current());
+        $middleware->seek(3);
         $this->assertInstanceOf(RoutingMiddleware::class, $middleware->current());
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses the concerns raised in #1071 regarding the Host Header Injection security fix. The original implementation threw an exception in `bootstrap.php` before error handling was initialized, causing:

- Blank pages in production (no error rendering)
- No logging (Log::setConfig() hadn't run yet)
- Issues with cache-based error rendering

This PR moves the security check to a dedicated `HostHeaderMiddleware` that runs after `ErrorHandlerMiddleware`, ensuring proper error handling.

### Changes

- **New `HostHeaderMiddleware`**: Validates Host header in production mode
  - Throws `InternalErrorException` if `App.fullBaseUrl` is not configured
  - Throws `BadRequestException` if Host header doesn't match configured URL
  - Skips validation in debug mode (development)
- **Updated `Application.php`**: Adds middleware after `ErrorHandlerMiddleware`
- **Simplified `bootstrap.php`**: Removes the exception throwing, keeps development fallback

### Benefits

- Errors are properly rendered by `ErrorHandlerMiddleware`
- Logging works correctly
- CLI commands are not affected
- Additionally validates that incoming Host header matches the configured URL

Fixes concerns from #1071.