### PR TITLE
Add generic type annotation to AppView

### DIFF
--- a/src/View/AppView.php
+++ b/src/View/AppView.php
@@ -23,6 +23,7 @@ use Cake\View\View;
  * Your application's default view class
  *
  * @link https://book.cakephp.org/5/en/views.html#the-app-view
+ * @extends \Cake\View\View<\App\View\AppView>
  */
 class AppView extends View
 {


### PR DESCRIPTION
## Summary

Fixes PHPStan error introduced after core added `@template TSubject` to the `View` class in cakephp/cakephp@4728e8a (Dec 22, 2025).

The error was:
```
Class App\View\AppView extends generic class Cake\View\View but does not specify its types: TSubject
```

This adds the required `@extends` annotation to satisfy PHPStan.