### PR TITLE
Fix wrong domain used as example

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -20,7 +20,7 @@ export APP_DEFAULT_LOCALE="en_US"
 export APP_DEFAULT_TIMEZONE="UTC"
 # SECURITY: Set this to your domain to prevent Host Header Injection attacks
 # This is REQUIRED in production for password resets and other security features
-export APP_FULL_BASE_URL="https://yourdomain.com"
+export APP_FULL_BASE_URL="https://example.com"
 export SECURITY_SALT="__SALT__"
 
 # Uncomment these to define cache configuration via environment variables.

--- a/config/app.php
+++ b/config/app.php
@@ -40,7 +40,7 @@ return [
      *   IMPORTANT: This MUST be set in production to prevent Host Header Injection attacks
      *   that can compromise password reset and other security-critical features.
      *   Set this via APP_FULL_BASE_URL environment variable or directly in config.
-     *   Example: 'https://yourdomain.com'
+     *   Example: 'https://example.com'
      *   When not set, the application will throw an exception in production mode.
      * - imageBaseUrl - Web path to the public images/ directory under webroot.
      * - cssBaseUrl - Web path to the public css/ directory under webroot.

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -156,7 +156,7 @@ if (PHP_SAPI === 'cli') {
  * Set APP_FULL_BASE_URL in your environment variables or configure App.fullBaseUrl
  * in config/app.php or config/app_local.php
  *
- * Example: APP_FULL_BASE_URL=https://yourdomain.com
+ * Example: APP_FULL_BASE_URL=https://example.com
  */
 $fullBaseUrl = Configure::read('App.fullBaseUrl');
 if (!$fullBaseUrl) {


### PR DESCRIPTION
The previous domain used yourdomain.com redirects to an Adult Website. Updating to example.com because it is a safe domain for base config.