### PR TITLE
Remove stale generic annotation on Application class

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -35,8 +35,6 @@ use Cake\Routing\Middleware\RoutingMiddleware;
  *
  * This defines the bootstrapping logic and middleware layers you
  * want to use in your application.
- *
- * @extends \Cake\Http\BaseApplication<\App\Application>
  */
 class Application extends BaseApplication
 {


### PR DESCRIPTION
Fixes the PHPStan error every fresh 5.x app hits after installing CakePHP 5.4:

```
src/Application.php:41
PHPDoc tag @extends contains generic type Cake\Http\BaseApplication<App\Application>
but class Cake\Http\BaseApplication is not generic. (generics.notGeneric)
```

CakePHP 5.4.0 removed the template from `Cake\Http\BaseApplication` (commit `ba510db081`, "Simplify generics template for event subject"):

```
- * @template TSubject of \Cake\Http\BaseApplication
- * @implements \Cake\Event\EventDispatcherInterface<TSubject>
- * @implements \Cake\Core\PluginApplicationInterface<TSubject>
```

The event subject template now defaults to `$this` on `EventDispatcherInterface`/`EventDispatcherTrait`, so the skeleton no longer needs to name it - and naming it is now an error.

This branch pins `cakephp/cakephp: 5.4.*`, so removal is safe here. `5.next` still pins `5.3.*`, where `BaseApplication` is generic, so it is intentionally left alone.

Reported in cakephp/cakephp#19583.
